### PR TITLE
Composite ref

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -217,7 +217,7 @@ rule get_host_removed_reads:
     benchmark:
         "{sn}/benchmarks/{sn}_get_host_removed_reads.benchmark.tsv"
     log:
-        '{sn}/host_removal/{sn}_bamtofastq.log'
+        '{sn}/host_removal/{sn}_samtools_fastq.log'
     shell:
         """
         samtools view -b {input} | samtools sort -n -@{threads} > {output.bam} 2> {log}
@@ -349,7 +349,7 @@ rule get_mapping_reads:
     benchmark:
         "{sn}/benchmarks/{sn}_get_mapping_reads.benchmark.tsv"
     log:
-        '{sn}/mapped_clean_reads/{sn}_bamtofastq.log'
+        '{sn}/mapped_clean_reads/{sn}_samtools_fastq.log'
     shell:
         """
         samtools sort -n {input} -o {output.bam} 2> {log}
@@ -425,7 +425,7 @@ rule run_breseq:
         labelled_output_dir = '{sn}/breseq/{sn}_output'
     shell:
         """
-        breseq --reference {params.ref} --num-processors {threads} --polymorphism-prediction --brief-html-output --output {params.outdir} {input} >{log} 2>&1
+        breseq --reference {params.ref} --num-processors {threads} --polymorphism-prediction --brief-html-output --output {params.outdir} {input} > {log} 2>&1
         mv -T {params.unlabelled_output_dir} {params.labelled_output_dir}
         """
 

--- a/conda_envs/snp_mapping.yaml
+++ b/conda_envs/snp_mapping.yaml
@@ -4,7 +4,8 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bwa=0.7.17=hed695b0_7
+  - bwa=0.7.17
   - samtools=1.7=2
   - bedtools=2.26.0=0
-  - breseq=0.35.0=h8b12597_0
+  - breseq=0.35.0
+  - pysam

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,6 +1,9 @@
 # This file contains a high-level summary of pipeline configuration and inputs.
 # It is ingested by the Snakefile, and also intended to be human-readable.
 
+# Sample table (can be created using example_sample_table.csv)
+samples: "sample_table.csv"
+
 # Folder to place all results (can be relative or absolute path)
 result_dir: "results_dir"
 
@@ -10,15 +13,16 @@ min_qual: 20
 # Minimum read length to retain after trimming, used in 'trim_galore' and 'ivar trim'
 min_len: 20
 
-# path from snakemake dir to .bed file defining amplicon primer scheme
+# Path from snakemake dir to .bed file defining amplicon primer scheme
 scheme_bed: 'resources/primer_schemes/nCoV-2019_v3_fixed.bed'
 
-# path from snakemake dir to bwa indexed human reference genome
+# Path from snakemake dir to bwa indexed human + viral reference genome
 composite_reference: 'data/composite_human_viral_reference.fna'
 
 # Used as bwa reference genome when removing host sequences.
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
+# contig needed for hostremoval filtering script
 viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'
@@ -39,8 +43,6 @@ ivar_min_coverage_depth: 10
 ivar_min_freq_threshold: 0.25
 # iVar minimum mapQ to call variant (ivar variants: -q)
 ivar_min_variant_quality: 20
-
-samples: "sample_table.csv"
 
 # fasta of sequences to include with phylo
 phylo_include_seqs: "data/gisaid_hcov-19_2020_05_25_23.fasta"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -14,11 +14,12 @@ min_len: 20
 scheme_bed: 'resources/primer_schemes/nCoV-2019_v3_fixed.bed'
 
 # path from snakemake dir to bwa indexed human reference genome
-human_reference: 'data/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna'
+composite_reference: 'data/composite_human_viral_reference.fna'
 
 # Used as bwa reference genome when removing host sequences.
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
+viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'
 

--- a/scripts/filter_non_human_reads.py
+++ b/scripts/filter_non_human_reads.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+import pysam
+import sys
+import argparse
+
+def filter_reads(contig_name, input_sam_fp, output_bam_fp):
+
+    # use streams if args are None
+    if input_sam_fp:
+        input_sam = pysam.AlignmentFile(input_sam_fp, 'r')
+    else:
+        input_sam = pysam.AlignmentFile('-', 'r')
+
+    if output_bam_fp:
+        output_bam = pysam.AlignmentFile(output_bam_fp, 'wb',
+                                         template=input_sam)
+    else:
+        output_bam = pysam.AlignmentFile('-', 'wb', template=input_sam)
+
+    # if read isn't mapped or mapped to viral reference contig name
+    viral_reads = 0
+    human_reads = 0
+    unmapped_reads = 0
+
+    # iterate over input from BWA
+    for read in input_sam:
+        # only look at primary alignments
+        if not read.is_supplementary or not read.is_secondary:
+            if read.reference_name == contig_name:
+                output_bam.write(read)
+                viral_reads += 1
+            elif read.is_unmapped:
+                output_bam.write(read)
+                unmapped_reads +=1
+            else:
+                human_reads += 1
+    total_reads = viral_reads + human_reads + unmapped_reads
+    print(f"viral read count = {viral_reads} "
+            f"({viral_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+    print(f"human read count = {human_reads} "
+            f"({human_reads/total_reads * 100:.2f}%) ", file=sys.stderr)
+    print(f"unmapped read count = {unmapped_reads} "
+            f"({unmapped_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="Get all reads that are "
+                                                  "unmapped and map to a "
+                                                  "specific reference "
+                                                  "contig")
+    parser.add_argument('-i', '--input', required=False, default=False,
+                        help="Input SAM formatted file (stdin used if "
+                              " not specified)")
+
+    parser.add_argument('-o', '--output', required=False, default=False,
+                        help="Output BAM formatted file (stdout used if not "
+                             "specified)")
+
+    parser.add_argument('-c', '--contig_name', required=False,
+                        default="MN908947.3",
+                        help="Contig name to retain e.g. viral")
+
+    args = parser.parse_args()
+
+    filter_reads(args.contig_name, args.input, args.output)

--- a/scripts/filter_non_human_reads.py
+++ b/scripts/filter_non_human_reads.py
@@ -25,17 +25,18 @@ def filter_reads(contig_name, input_sam_fp, output_bam_fp):
     # iterate over input from BWA
     for read in input_sam:
         # only look at primary alignments
-        if not read.is_supplementary
-            if not read.is_secondary:
-                if read.reference_name == contig_name:
-                    output_bam.write(read)
-                    viral_reads += 1
-                elif read.is_unmapped:
-                    output_bam.write(read)
-                    unmapped_reads +=1
-                else:
-                    human_reads += 1
+        if not read.is_supplementary and not read.is_secondary:
+            if read.reference_name == contig_name:
+                output_bam.write(read)
+                viral_reads += 1
+            elif read.is_unmapped:
+                output_bam.write(read)
+                unmapped_reads +=1
+            else:
+                human_reads += 1
+
     total_reads = viral_reads + human_reads + unmapped_reads
+
     print(f"viral read count = {viral_reads} "
             f"({viral_reads/total_reads * 100:.2f}%)", file=sys.stderr)
     print(f"human read count = {human_reads} "

--- a/scripts/filter_non_human_reads.py
+++ b/scripts/filter_non_human_reads.py
@@ -25,15 +25,16 @@ def filter_reads(contig_name, input_sam_fp, output_bam_fp):
     # iterate over input from BWA
     for read in input_sam:
         # only look at primary alignments
-        if not read.is_supplementary or not read.is_secondary:
-            if read.reference_name == contig_name:
-                output_bam.write(read)
-                viral_reads += 1
-            elif read.is_unmapped:
-                output_bam.write(read)
-                unmapped_reads +=1
-            else:
-                human_reads += 1
+        if not read.is_supplementary
+            if not read.is_secondary:
+                if read.reference_name == contig_name:
+                    output_bam.write(read)
+                    viral_reads += 1
+                elif read.is_unmapped:
+                    output_bam.write(read)
+                    unmapped_reads +=1
+                else:
+                    human_reads += 1
     total_reads = viral_reads + human_reads + unmapped_reads
     print(f"viral read count = {viral_reads} "
             f"({viral_reads/total_reads * 100:.2f}%)", file=sys.stderr)

--- a/scripts/get_data_dependencies.sh
+++ b/scripts/get_data_dependencies.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit if pipeline returns non-zero status
 set -o pipefail # return value of last command to exit with non-zero status
+source ~/.bashrc
 
 database_dir=0
 accession="MN908947.3"
@@ -31,24 +32,29 @@ echo -e "Warning: \n - final databases require ~10GB of storage\n - building dat
 mkdir -p $database_dir
 database_dir=$(realpath $database_dir)
 
-# use curl to grab "simple data dependencies"
-curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
-curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
-curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
-curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
+## use curl to grab "simple data dependencies"
+#curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
+#curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
+#curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
+#curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
+#
+## install and activate env for lmat/kraken to build their databases
+#$CONDA_EXE create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8 bwa
+#CONDA_BASE=$($CONDA_EXE info --base)
+#source $CONDA_BASE/etc/profile.d/conda.sh
+#conda activate data_dependencies
+#
+## get kraken2, and clean db after building
+#kraken2-build --download-taxonomy --db $database_dir/Kraken2/db --threads 10 --use-ftp
+#kraken2-build --download-library viral --db $database_dir/Kraken2/db --threads 10 --use-ftp
+#kraken2-build --build --threads 10 --db $database_dir/Kraken2/db
+#kraken2-build --clean --threads 10 --db $database_dir/Kraken2/db
+#
+## get the GRCh38 BWA index human genome
+#curl -s "ftp://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh38_latest/refseq_identifiers/GRCh38_latest_genomic.fna.gz" > $database_dir/GRC38_latest_genomic.fna.gz
+#gunzip $database_dir/GRC38_latest_genomic.fna.gz
 
-# install and activate env for lmat/kraken to build their databases
-conda create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8
-CONDA_BASE=$(conda info --base)
-source $CONDA_BASE/etc/profile.d/conda.sh
-conda activate data_dependencies
-
-# get kraken2, and clean db after building
-kraken2-build --download-taxonomy --db $database_dir/Kraken2/db --threads 10 --use-ftp
-kraken2-build --download-library viral --db $database_dir/Kraken2/db --threads 10 --use-ftp
-kraken2-build --build --threads 10 --db $database_dir/Kraken2/db
-kraken2-build --clean --threads 10 --db $database_dir/Kraken2/db
-
-# get the GRCh38 BWA index human genome
-curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.bwa_index.tar.gz" > $database_dir/GRCh38_bwa.tar.gz
-tar xvf $database_dir/GRCh38_bwa.tar.gz -C $database_dir
+# create composite reference of human and virus for competitive bwt mapping 
+# based host removal
+cat $database_dir/GRC38_latest_genomic.fna $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
+bwa index $database_dir/composite_human_viral_reference.fna

--- a/scripts/get_data_dependencies.sh
+++ b/scripts/get_data_dependencies.sh
@@ -32,29 +32,31 @@ echo -e "Warning: \n - final databases require ~10GB of storage\n - building dat
 mkdir -p $database_dir
 database_dir=$(realpath $database_dir)
 
-## use curl to grab "simple data dependencies"
-#curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
-#curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
-#curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
-#curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
-#
-## install and activate env for lmat/kraken to build their databases
-#$CONDA_EXE create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8 bwa
-#CONDA_BASE=$($CONDA_EXE info --base)
-#source $CONDA_BASE/etc/profile.d/conda.sh
-#conda activate data_dependencies
-#
-## get kraken2, and clean db after building
-#kraken2-build --download-taxonomy --db $database_dir/Kraken2/db --threads 10 --use-ftp
-#kraken2-build --download-library viral --db $database_dir/Kraken2/db --threads 10 --use-ftp
-#kraken2-build --build --threads 10 --db $database_dir/Kraken2/db
-#kraken2-build --clean --threads 10 --db $database_dir/Kraken2/db
-#
-## get the GRCh38 BWA index human genome
-#curl -s "ftp://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/annotation/GRCh38_latest/refseq_identifiers/GRCh38_latest_genomic.fna.gz" > $database_dir/GRC38_latest_genomic.fna.gz
-#gunzip $database_dir/GRC38_latest_genomic.fna.gz
+# use curl to grab "simple data dependencies"
+curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
+curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
+curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
+curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
+
+# install and activate env for lmat/kraken to build their databases
+$CONDA_EXE create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8 bwa
+CONDA_BASE=$($CONDA_EXE info --base)
+source $CONDA_BASE/etc/profile.d/conda.sh
+conda activate data_dependencies
+
+# get kraken2, and clean db after building
+kraken2-build --download-taxonomy --db $database_dir/Kraken2/db --threads 10 --use-ftp
+kraken2-build --download-library viral --db $database_dir/Kraken2/db --threads 10 --use-ftp
+kraken2-build --build --threads 10 --db $database_dir/Kraken2/db
+kraken2-build --clean --threads 10 --db $database_dir/Kraken2/db
+
+# get the GRCh38 human genome
+# as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use
+curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > $database_dir/GRC38_no_alt_analysis_set.fna.gz
+gunzip $database_dir/GRC38_no_alt_analysis_set.fna.gz
+
 
 # create composite reference of human and virus for competitive bwt mapping 
 # based host removal
-cat $database_dir/GRC38_latest_genomic.fna $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
+cat $database_dir/GRC38_no_alt_analysis_set.fna.gz $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
 bwa index $database_dir/composite_human_viral_reference.fna

--- a/scripts/get_data_dependencies.sh
+++ b/scripts/get_data_dependencies.sh
@@ -39,24 +39,23 @@ curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&
 curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
 
 # install and activate env for lmat/kraken to build their databases
-$CONDA_EXE create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8 bwa
+#$CONDA_EXE create -n data_dependencies -c conda-forge -c bioconda -y kraken2=2.0.8 bwa
 CONDA_BASE=$($CONDA_EXE info --base)
 source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate data_dependencies
-
+#
 # get kraken2, and clean db after building
 kraken2-build --download-taxonomy --db $database_dir/Kraken2/db --threads 10 --use-ftp
 kraken2-build --download-library viral --db $database_dir/Kraken2/db --threads 10 --use-ftp
 kraken2-build --build --threads 10 --db $database_dir/Kraken2/db
 kraken2-build --clean --threads 10 --db $database_dir/Kraken2/db
-
+#
 # get the GRCh38 human genome
 # as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use
 curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > $database_dir/GRC38_no_alt_analysis_set.fna.gz
 gunzip $database_dir/GRC38_no_alt_analysis_set.fna.gz
 
-
 # create composite reference of human and virus for competitive bwt mapping 
 # based host removal
-cat $database_dir/GRC38_no_alt_analysis_set.fna.gz $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
+cat $database_dir/GRC38_no_alt_analysis_set.fna $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
 bwa index $database_dir/composite_human_viral_reference.fna


### PR DESCRIPTION
Merge change to use competitive mapping to composite reference.

Testing shows this successfully extracts all spiked-in reads, and all the output have the correct number of reads.

The added script outputs information about the removal to stderr (total reads not paired)
`viral read count = 206600 (91.16%)`
`human read count = 20027 (8.84%)`
`unmapped read count = 11 (0.00%)`

This is captured into the `results_dir/*/host_removal/*_human_read_mapping.log` log files so could be added to the summary report too. 

I also note the kraken2 db downloaded in the `scripts/get_data_dependencies.sh` is only viral reference.  Are we sure we don't want to keep human in this so we have that as an extra QC report? 

Closes #85 #79 