### PR TITLE
Adding python 3.6.5 dependency since pysam is not yet compatible with Python 3.8.5

### DIFF
--- a/conda_envs/snp_mapping.yaml
+++ b/conda_envs/snp_mapping.yaml
@@ -9,3 +9,4 @@ dependencies:
   - bedtools=2.26.0=0
   - breseq=0.35.0
   - pysam
+  - python=3.6.5


### PR DESCRIPTION
Been having issues with python versioning. For whatever reason if no Python version is specified as a dependency the program is pulling a pre-Python 3.6.5 version from the system to run scripts/filter_non_human_reads.py (even though conda itself is running under Python 3.8.5). This fails due to the use of f-strings in that script.

If the Python dependency is explicitly put as 3.8+, conda find conflicts since pysam is not yet compatible with 3.8+ (see https://github.com/pysam-developers/pysam/issues/924).

Have therefore put in a Python 3.6.5 dependency, as this is the first version with official support for f-strings.