### PR TITLE
Update SIGNAL for Pangolin v4.0+ compatibility

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -66,7 +66,8 @@ versions = {'pangolin': config['pangolin'],
             'pangolearn': config['pangolearn'],
             'constellations': config['constellations'],
             'scorpio': config['scorpio'],
-            'pango-designation': config['pango-designation']
+            'pango-designation': config['pango-designation'],
+            'pangolin-data': config['pangolin-data']
             }
 
 def get_input_fastq_files(sample_name, r):
@@ -770,9 +771,10 @@ rule run_lineage_assignment:
         constellations_ver = versions['constellations'],
         scorpio_ver = versions['scorpio'],
         designation_ver = versions['pango-designation'],
+        data_ver = versions['pangolin-data'],
         assignment_script_path = os.path.join(exec_dir, 'scripts', 'assign_lineages.py')
     shell:
-        "echo -e 'pangolin: {params.pangolin_ver}\npangolearn: {params.pangolearn_ver}\nconstellations: {params.constellations_ver}\nscorpio: {params.scorpio_ver}\npango-designation: {params.designation_ver}' > {output.ver_out} && "
+        "echo -e 'pangolin: {params.pangolin_ver}\nconstellations: {params.constellations_ver}\nscorpio: {params.scorpio_ver}\npangolearn: {params.pangolearn_ver}\npango-designation: {params.designation_ver}\npangolin-data: {params.data_ver}' > {output.ver_out} && "
         'cat {input} > all_genomes.fa && '
         '{params.assignment_script_path} -i all_genomes.fa -t {threads} -o {output.lin_out} -p {output.ver_out}'
 

--- a/conda_envs/assign_lineages.yaml
+++ b/conda_envs/assign_lineages.yaml
@@ -20,3 +20,4 @@ dependencies:
     - git+https://github.com/cov-lineages/constellations.git
     - git+https://github.com/cov-lineages/pangolin.git
     - git+https://github.com/cov-lineages/pango-designation.git
+    - git+https://github.com/cov-lineages/pangolin-data.git

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -115,23 +115,41 @@ def collate_output(nextclade, pangolin, output):
     """
     merged_df = pangolin.merge(nextclade, on='isolate', how='outer')
 
-    merged_df = merged_df[['isolate', 'pango_lineage',
-                           'pangolin_conflict', 'pangolin_ambiguity_score',
-                           'pangolin_note', 'scorpio_call', 'scorpio_support',
-                           'scorpio_conflict',
-                           'pangolin_qc', 'nextstrain_clade',
-                           'nextclade_qc', 'nextclade_errors',
-                           'totalGaps', 'totalInsertions', 'totalMissing',
-                           'totalMutations', 'totalNonACGTNs',
-                           'totalPcrPrimerChanges',
-                           'substitutions', 'deletions', 'insertions',
-                           'missing', 'nonACGTNs',
-                           'pcrPrimerChanges', 'aaSubstitutions',
-                           'totalAminoacidSubstitutions',
-                           'aaDeletions', 'totalAminoacidDeletions',
-                           'alignmentStart', 'alignmentEnd', 'alignmentScore',
-                           'pangolin_version', 'pango_version',
-                           'pangoLEARN_version', 'pango_version', 'nextclade_version']]
+    try:
+        merged_df = merged_df[['isolate', 'pango_lineage',
+                               'pangolin_conflict', 'pangolin_ambiguity_score',
+                               'pangolin_note', 'scorpio_call', 'scorpio_support',
+                               'scorpio_conflict',
+                               'pangolin_qc', 'nextstrain_clade',
+                               'nextclade_qc', 'nextclade_errors',
+                               'totalGaps', 'totalInsertions', 'totalMissing',
+                               'totalMutations', 'totalNonACGTNs',
+                               'totalPcrPrimerChanges',
+                               'substitutions', 'deletions', 'insertions',
+                               'missing', 'nonACGTNs',
+                               'pcrPrimerChanges', 'aaSubstitutions',
+                               'totalAminoacidSubstitutions',
+                               'aaDeletions', 'totalAminoacidDeletions',
+                               'alignmentStart', 'alignmentEnd', 'alignmentScore',
+                               'pangolin_version', 'pango_version',
+                               'pangoLEARN_version', 'pango_version', 'nextclade_version']]
+    except KeyError: # adjust for pangolin v4
+        merged_df = merged_df[['isolate', 'pango_lineage',
+                               'pangolin_conflict', 'pangolin_ambiguity_score',
+                               'pangolin_note', 'scorpio_call', 'scorpio_support',
+                               'scorpio_conflict',
+                               'nextstrain_clade',
+                               'nextclade_qc', 'nextclade_errors',
+                               'totalGaps', 'totalInsertions', 'totalMissing',
+                               'totalMutations', 'totalNonACGTNs',
+                               'totalPcrPrimerChanges',
+                               'substitutions', 'deletions', 'insertions',
+                               'missing', 'nonACGTNs',
+                               'pcrPrimerChanges', 'aaSubstitutions',
+                               'totalAminoacidSubstitutions',
+                               'aaDeletions', 'totalAminoacidDeletions',
+                               'alignmentStart', 'alignmentEnd', 'alignmentScore', 
+                               'version','pangolin_version', 'nextclade_version']]
     merged_df.to_csv(output, sep='\t', index=False)
 
 

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -621,18 +621,27 @@ def parse_lineage(tsv_filename, sample_names, allow_missing=True):
             samples[name] = { 'lineage' : None,
                               'clade': None,
                               'pangolin_ver': None,
-                              'pangolearn_ver': None,
+                              'pangodata_ver': None,
                               'nextclade_ver': None }
         return { 'samples': samples }
 
     lineages = pd.read_table(tsv_filename, sep='\t')
-    df = lineages[['isolate',
-                    'pango_lineage',
-                    'nextstrain_clade',
-                    'pangolin_version',
-                    'pangoLEARN_version',
-                    'nextclade_version'
-                    ]]
+    try:
+        df = lineages[['isolate',
+                        'pango_lineage',
+                        'nextstrain_clade',
+                        'pangolin_version',
+                        'pangoLEARN_version',
+                        'nextclade_version'
+                        ]]
+    except KeyError:
+        df = lineages[['isolate',
+                        'pango_lineage',
+                        'nextstrain_clade',
+                        'pangolin_version',
+                        'version',
+                        'nextclade_version'
+                        ]]
 
     # Pull each row, identify sid 
     for row in df.itertuples():
@@ -647,12 +656,15 @@ def parse_lineage(tsv_filename, sample_names, allow_missing=True):
         lineage = str(row.pango_lineage)
         clade = str(row.nextstrain_clade)
         pangolin = str(row.pangolin_version)
-        pangolearn = str(row.pangoLEARN_version)
+        try:
+            pangodata = str(row.pangoLEARN_version)
+        except AttributeError:
+            pangodata = str(row.version)
         nextclade = str(row.nextclade_version)
         samples[sid] = { 'lineage' : lineage,
                          'clade': clade,
                          'pangolin_ver': pangolin,
-                         'pangolearn_ver': pangolearn,
+                         'pangodata_ver': pangodata,
                          'nextclade_ver': nextclade }
 
     assert len(samples) == len(sample_names)
@@ -1329,16 +1341,16 @@ class Sample:
 
         if ivarlin['lineage'] != fblin['lineage'] and fblin['lineage'] is not None:
             assert ivarlin['pangolin_ver'] == fblin['pangolin_ver']
-            assert ivarlin['pangolearn_ver'] == fblin['pangolearn_ver']
+            assert ivarlin['pangodata_ver'] == fblin['pangodata_ver']
             if ivarlin['clade'] == fblin['clade']:
                  self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
                                  'pangolin_ver': ivarlin['pangolin_ver'],
-                                 'pangolearn_ver': ivarlin['pangolearn_ver'],
+                                 'pangodata_ver': ivarlin['pangodata_ver'],
                                  'clade': ivarlin['clade'] }
             else:
                  self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
                                  'pangolin_ver': ivarlin['pangolin_ver'],
-                                 'pangolearn_ver': ivarlin['pangolearn_ver'],
+                                 'pangodata_ver': ivarlin['pangodata_ver'],
                                  'clade': str(ivarlin['clade'] + " (FB: %s)" %(fblin['clade'])) }
         else:
             self.lineage = ivarlin

--- a/signal.py
+++ b/signal.py
@@ -191,10 +191,15 @@ var_min_variant_quality: 20
 
 # Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates are accepted for pangolearn. Leave blank for latest version(s).
 pangolin: 
-pangolearn: 
 constellations:
 scorpio:
+
+# Required for Pangolin <v4.0
+pangolearn: 
 pango-designation:
+
+# Required for Pangolin v4+
+pangolin-data:
 
 # ANYTHING BELOW IS ONLY NEEDED IF USING NCOV-TOOLS SUMMARIES
 # Path from snakemake dir to .bed file defining the actual amplicon locations not the primers


### PR DESCRIPTION
`pangolin-data` aims to replace the `pangoLEARN` and `pango-designation` requirements come Pangolin v4.0 onwards. However, since we have version control for lineage assigning software, the former requirements are still needed to run previous versions of Pangolin.

Version control should update all dependencies, old and new, with output adjusting depending on whether the old or new Pangolin output format (via column checks) is found. 