### PR TITLE
Update nextclade and pangolin toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ Additional software dependencies are managed directly by `snakemake` using conda
 - ivar 1.3 ([docs](https://github.com/andersen-lab/ivar))
 - freebayes 1.3.2 ([docs](https://github.com/freebayes/freebayes))
 - pangolin (latest; version can be specified by user) [(docs)](https://github.com/cov-lineages/pangolin)
+- pangolin-data (latest; version can be specified by user; required for Pangolin v4+) [(docs)](https://github.com/cov-lineages/pangolin-data)
 - pangolearn (latest; version can be specified by user) [(docs)](https://github.com/cov-lineages/pangoLEARN)
 - constellations (latest; version can be specified by user) [(docs)](https://github.com/cov-lineages/constellations)
 - scorpio (latest; version can be specified by user) [(docs)](https://github.com/cov-lineages/scorpio)
 - pango-designation (latest; version can be specified by user) [(docs)](https://github.com/cov-lineages/pango-designation)
-- ncov-tools postprocessing scripts require additional dependencies (see [file](ncov-tools/workflow/envs/environment.yml)).
+- nextclade (v1.11.0) [(docs)](https://docs.nextstrain.org/projects/nextclade/en/stable/)
+- ncov-tools postprocessing scripts require additional dependencies (see [file](https://github.com/jts/ncov-tools/blob/master/workflow/envs/environment.yml)).
 
 ## SIGNAL Help Screen:
 
@@ -236,7 +238,7 @@ The main rules of the pipeline are as followed:
 
 - `all` = Sequencing pipeline. i.e., take a set of paired reads, perform reference-based assembly to generate a consensus, run lineage assignment, etc.
 - `postprocess` = Summarize the key results including pangolin lineage, specific mutations, etc, after running `all`
-- `ncov_tools` = Create the required conda environment, generate the necessary configuration file, and link needed result files within the `ncov-tools` directory. Manual run of ncov-tools is required.
+- `ncov_tools` = Create the required conda environment, generate the necessary configuration file, and link needed result files within the `ncov-tools` directory. `ncov-tools` will then be executed with output found within the SIGNAL directory.
 
 The generated configuration file from the above steps can be used as input. To run the general pipeline:
 

--- a/Snakefile
+++ b/Snakefile
@@ -69,7 +69,7 @@ versions = {'pangolin': config['pangolin'],
             'pango-designation': config['pango-designation'],
             'pangolin-data': config['pangolin-data'],
             'nextclade-data': config['nextclade-data'],
-            'nextclade-recomb': config['nextclade-recomb']
+            'nextclade-recomb': config['nextclade-include-recomb']
             }
 
 def get_input_fastq_files(sample_name, r):

--- a/Snakefile
+++ b/Snakefile
@@ -792,10 +792,11 @@ rule run_lineage_assignment_freebayes:
     output:
         'freebayes_lineage_assignments.tsv'
     input:
-        vers = 'input_pangolin_versions.txt',
+        p_vers = 'input_pangolin_versions.txt',
+        n_vers = 'input_nextclade_versions.txt',
         consensus = expand('{sn}/freebayes/{sn}.consensus.fasta', sn=sample_names)
     params:
         assignment_script_path = os.path.join(exec_dir, 'scripts', 'assign_lineages.py'),
     shell:
         'cat {input.consensus} > all_freebayes_genomes.fa && '
-        '{params.assignment_script_path} -i all_freebayes_genomes.fa -t {threads} -o {output} -p {input.vers} --skip'
+        '{params.assignment_script_path} -i all_freebayes_genomes.fa -t {threads} -o {output} -p {input.p_vers} -n {input.n_vers} --skip'

--- a/conda_envs/assign_lineages.yaml
+++ b/conda_envs/assign_lineages.yaml
@@ -14,6 +14,7 @@ dependencies:
   - usher
   - pandas
   - pysam==0.16.0.1
+  - nextclade
   - pip:
     - git+https://github.com/cov-lineages/pangoLEARN.git
     - git+https://github.com/cov-lineages/scorpio.git

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -10,6 +10,7 @@ result_dir: "results_dir"
 # Minimum quality threshold, used in 'trim_galore' and 'ivar trim'
 min_qual: 20
 
+
 # Minimum read length to retain after trimming, used in 'trim_galore' and 'ivar trim'
 min_len: 20
 
@@ -23,6 +24,7 @@ composite_reference: 'data/composite_human_viral_reference.fna'
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
 # contig needed for hostremoval filtering script
+# contig name used as reference for nextclade dataset
 viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'
@@ -59,6 +61,7 @@ var_min_variant_quality: 20
 pangolin: 
 constellations:
 scorpio:
+nextclade-data:
 
 # Required for Pangolin <v4.0
 pangolearn: 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -56,11 +56,14 @@ var_min_freq_threshold: 0.25
 # iVar/freebayes minimum mapQ to call variant (ivar variants: -q)
 var_min_variant_quality: 20
 
-# Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates are accepted for pangolearn. Leave blank for latest version(s).
+# Toggle faster Pangolin analysis at the cost of accuracy (uses Pangolearn instead of Usher)
+# Use for significantly larger datasets
+pangolin_fast: False
+
+# Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates (YYYY-mm-dd) are accepted for pangolearn. Leave blank for latest version(s).
 pangolin: 
 constellations:
 scorpio:
-nextclade-data:
 
 # Required for Pangolin <v4.0
 pangolearn: 
@@ -68,6 +71,12 @@ pango-designation:
 
 # Required for Pangolin v4+
 pangolin-data:
+
+# Required for Nextclade (datasets)
+# Be as specific as possible with the desired tag. Can accept dates (YYYY-mm-dd) alone, but will assume corresponding timestamp (HH:MM:SS). Typical tag format is YYYY-mm-ddTHH:MM:SSZ
+# Setting nextclade-include-recomb to False will download the recombinant-sequence free version of the Nextclade database
+nextclade-data:
+nextclade-include-recomb: True
 
 # ANYTHING BELOW IS ONLY NEEDED IF USING NCOV-TOOLS SUMMARIES
 # Path from snakemake dir to .bed file defining the actual amplicon locations not the primers

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -74,6 +74,7 @@ pangolin-data:
 
 # Required for Nextclade (datasets)
 # Be as specific as possible with the desired tag. Can accept dates (YYYY-mm-dd) alone, but will assume corresponding timestamp (HH:MM:SS). Typical tag format is YYYY-mm-ddTHH:MM:SSZ
+# Leave blank for latest dataset
 # Setting nextclade-include-recomb to False will download the recombinant-sequence free version of the Nextclade database
 nextclade-data:
 nextclade-include-recomb: True

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -24,7 +24,6 @@ composite_reference: 'data/composite_human_viral_reference.fna'
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
 # contig needed for hostremoval filtering script
-# contig name used as reference for nextclade dataset
 viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'

--- a/resources/config.schema.yaml
+++ b/resources/config.schema.yaml
@@ -79,6 +79,14 @@ pangolin-data:
     type: string
     default: "None"
     description: "Pangolin-data version"
+nextclade-data:
+    type: string
+    default: "None"
+    description: "Nextclade dataset date tag"
+nextclade-include-recomb:
+    type: boolean
+    default: True
+    description: "optionally download Nextclade dataset with or without recombinant sequences"
 required:
     - min_len
     - min_qual

--- a/resources/config.schema.yaml
+++ b/resources/config.schema.yaml
@@ -87,6 +87,10 @@ nextclade-include-recomb:
     type: boolean
     default: True
     description: "optionally download Nextclade dataset with or without recombinant sequences"
+pangolin_fast:
+    type: boolean
+    default: False
+    description: "toggle Pangolin faster analysis which uses pangolearn in place of usher at the cost of accuracy"
 required:
     - min_len
     - min_qual

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -66,6 +66,7 @@ def update_nextclade_dataset(vers, skip):
     # check nextclade_ver, if None, assign today's date
     try:
         if requested_ver != "None":
+            # assume yyyy-mm-dd (so only yyyy and mm expected to stay ccnsistent)
             submitted = requested_ver.split("-")
             submitted_date = [s.strip() for s in submitted]
             assert len(submitted_date) == 3
@@ -75,18 +76,18 @@ def update_nextclade_dataset(vers, skip):
                 if submitted_date[2].count("T") == 1: # only applies if starting input was in quotations itself in the config file
                     day = str(submitted_date[2]).split("T")[0].strip()
                     timestamp = str(submitted_date[2]).split("T")[1].split("+", 1)[0].split(":")
-                else:
+                else: 
                     day = str(submitted_date[2]).split(" ")[0].strip()
                     timestamp = str(submitted_date[2]).split(" ")[1].split("+", 1)[0].split(":")
                 tags = [timestamp[0], timestamp[1], timestamp[2].strip("Z")]
-            else:
+            else: # only a date provided, assume timestamp
                 day = str(submitted_date[2])
                 tags = ["12", "00", "00"]
             requested = str("%s-%s-%sT%s:%s:%sZ" %(year, month, day, tags[0], tags[1], tags[2]))
         else:
             requested = None
-    except (AssertionError, TypeError): # some other input that isn't in yyyy-mm-dd date format
-        print(f"\nProvided Nextclade dataset version invalid! Downloading latest...")
+    except (AssertionError, TypeError, ValueError): # some other input that isn't in yyyy-mm-dd date format
+        print(f"\nProvided Nextclade dataset tag invalid! Downloading latest...")
         requested = None
 
     if recomb:

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -7,6 +7,7 @@ import time
 import pandas as pd
 import shutil
 import os, sys
+from datetime import datetime
 
 
 def check_file(path: str) -> Path:

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -7,7 +7,6 @@ import time
 import pandas as pd
 import shutil
 import os, sys
-from datetime import datetime
 
 
 def check_file(path: str) -> Path:

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -62,8 +62,6 @@ def update_nextclade_dataset(vers, skip):
         requested_ver = str(line[0].split(":")[1]).strip()
         recomb = str(line[1].split(":")[1]).strip()
 
-    # check if installed, pull current tag
-    
     # check nextclade_ver, if None, assign today's date
     try:
         if requested_ver != "None":
@@ -73,7 +71,7 @@ def update_nextclade_dataset(vers, skip):
         else:
             requested = None
     except AssertionError: # some other input that isn't in yyyy-mm-dd date format
-        print(f"Provided Nextclade dataset version, invalid! Downloading latest...")
+        print(f"Provided Nextclade dataset version invalid! Downloading latest...")
         requested = None
 
     if recomb:
@@ -81,7 +79,7 @@ def update_nextclade_dataset(vers, skip):
     else:
         dataset = 'sars-cov-2-no-recomb'
 
-    # Determine if install required, if so, install dataset using nextclade dataset get
+    # If specific tag requested, attempt to install, otherwise install latest
     accession = 'MN908947'
     if requested is not None:
         try:

--- a/scripts/pangolin_specific_version_update.py
+++ b/scripts/pangolin_specific_version_update.py
@@ -64,8 +64,11 @@ if __name__ == "__main__":
 
 	# parse the dependency version file provided, validate real dependencies
 	# tidy up version strings, and then use pip to update
+	required = []
 	valid_deps = ['pangolin', 'pangolearn', 'constellations',
 				  'scorpio', 'pango-designation', 'pangolin-data']
+	required_v3 = ['pangolin', 'scorpio', 'constellations', 'pangolearn', 'pango-designation'] 
+	required_v4 = ['pangolin', 'scorpio', 'constellations', 'pangolin-data']
 	print("## Changing installed versions as needed:")
 	with open(args.versions_file) as fh:
 		for line in fh:
@@ -73,12 +76,25 @@ if __name__ == "__main__":
 			dependency = line[0].strip()
 			requested_ver = line[1].strip()
 
-			if dependency not in valid_deps:
-				raise ValueError(f"{dependency} is not a valid pangolin "
-								 f"dependency. Must be in {valid_deps}")
+			if dependency == "pangolin" and len(required) == 0:
+				if requested_ver.startswith("3") or requested_ver.startswith("v3"):
+					required = required_v3
+				elif requested_ver.startswith("4") or requested_ver.startswith("v4") or str(requested_ver) == "None":
+					required = required_v4
+				else:
+					required = valid_deps # no change to valid deps
+
+			if dependency not in required:
+				if dependency not in valid_deps:
+					raise ValueError(f"{dependency} is not a valid pangolin "
+									f"dependency. Must be in {required}")
+				else:
+					print(f"{dependency} not required! Skipping...")
+					continue
 
 			if dependency != "pangolearn" and not requested_ver.startswith("v"):
 				requested_ver = "v" + requested_ver
+			
 			
 			# Get latest version number to compare with installed when latest version is requested
 			try:
@@ -117,7 +133,7 @@ if __name__ == "__main__":
 				continue
 
 	# provides pangolin install details after update to specific versions in supplied version file
-	with open('final_versions.txt', 'w+') as out:
+	with open('final_pangolin_versions.txt', 'w+') as out:
 		print("## Pangolin and dependencies now:", file=out)
 		out_ver = subprocess.run(["pangolin", "--all-versions"], check=True, stdout=subprocess.PIPE)
 		print(out_ver.stdout.decode("utf-8").replace("[32m****\nPangolin running in usher mode.\n****[0m", "").strip(), file=out)

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -17,7 +17,7 @@ long_git_id = '$Id: b158164f87c79271ddc9d1083e64e4be1fc26d8e $'
 
 assert long_git_id.startswith('$Id: ')
 #short_git_id = long_git_id[5:12]
-short_git_id = "v1.5.2"
+short_git_id = "v1.5.3"
 
 # Suppresses matplotlib warning (https://github.com/jaleezyy/covid-19-signal/issues/59)
 # Creates a small memory leak, but it's nontrivial to fix, and won't be a practical concern!

--- a/signal.py
+++ b/signal.py
@@ -191,7 +191,7 @@ var_min_variant_quality: 20
 
 # Toggle faster Pangolin analysis at the cost of accuracy (uses Pangolearn instead of Usher)
 # Use for significantly larger datasets
-pangolin_fast: True
+pangolin_fast: False
 
 # Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates (YYYY-mm-dd) are accepted for pangolearn. Leave blank for latest version(s).
 pangolin: 

--- a/signal.py
+++ b/signal.py
@@ -207,6 +207,7 @@ pangolin-data:
 
 # Required for Nextclade (datasets)
 # Be as specific as possible with the desired tag. Can accept dates (YYYY-mm-dd) alone, but will assume corresponding timestamp (HH:MM:SS). Typical tag format is YYYY-mm-ddTHH:MM:SSZ
+# Leave blank for latest dataset
 # Setting nextclade-include-recomb to False will download the recombinant-sequence free version of the Nextclade database
 nextclade-data:
 nextclade-include-recomb: True

--- a/signal.py
+++ b/signal.py
@@ -157,7 +157,6 @@ composite_reference: 'data/composite_human_viral_reference.fna'
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
 # contig needed for hostremoval filtering script
-# contig name used as reference for nextclade dataset
 viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'

--- a/signal.py
+++ b/signal.py
@@ -157,6 +157,7 @@ composite_reference: 'data/composite_human_viral_reference.fna'
 # Also used as 'ivar' reference genome in variant detection + consensus.
 # Used as -r,-g arguments to 'quast'
 # contig needed for hostremoval filtering script
+# contig name used as reference for nextclade dataset
 viral_reference_contig_name: 'MN908947.3'
 viral_reference_genome: 'data/MN908947.3.fasta'
 viral_reference_feature_coords: 'data/MN908947.3.gff3'
@@ -200,6 +201,11 @@ pango-designation:
 
 # Required for Pangolin v4+
 pangolin-data:
+
+# Required for Nextclade (datasets)
+# Setting nextclade-include-recomb to False will download the recombinant-sequence free version of the Nextclade database
+nextclade-data:
+nextclade-include-recomb: True
 
 # ANYTHING BELOW IS ONLY NEEDED IF USING NCOV-TOOLS SUMMARIES
 # Path from snakemake dir to .bed file defining the actual amplicon locations not the primers

--- a/signal.py
+++ b/signal.py
@@ -189,7 +189,11 @@ var_min_freq_threshold: 0.25
 # iVar/freebayes minimum mapQ to call variant (ivar variants: -q)
 var_min_variant_quality: 20
 
-# Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates are accepted for pangolearn. Leave blank for latest version(s).
+# Toggle faster Pangolin analysis at the cost of accuracy (uses Pangolearn instead of Usher)
+# Use for significantly larger datasets
+pangolin_fast: True
+
+# Versions of software related to lineage calling (use numbers only, i.e., 3.1.1). Dates (YYYY-mm-dd) are accepted for pangolearn. Leave blank for latest version(s).
 pangolin: 
 constellations:
 scorpio:
@@ -202,6 +206,7 @@ pango-designation:
 pangolin-data:
 
 # Required for Nextclade (datasets)
+# Be as specific as possible with the desired tag. Can accept dates (YYYY-mm-dd) alone, but will assume corresponding timestamp (HH:MM:SS). Typical tag format is YYYY-mm-ddTHH:MM:SSZ
 # Setting nextclade-include-recomb to False will download the recombinant-sequence free version of the Nextclade database
 nextclade-data:
 nextclade-include-recomb: True


### PR DESCRIPTION
- Nextclade updated now through conda (replacing depreciated Node.js version)
- SIGNAL `all` output adjusted to newer nextclade version; SIGNAL `postprocess` summary output remains unchanged
- New parameters (`nextclade-data` and `nextclade-include-recomb`) allow for version selection for nextclade datasets (tags for both `sars-cov-2` and `sars-cov-2-no-recomb` datasets supported)
- New parameter (`pangolin_fast`) allows for for the alternate `pangolin --analysis-mode fast` to be executed, using Pangolearn in place of Usher