### PR TITLE
Update lineage assignment dependency

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -238,7 +238,8 @@ rule ncov_tools:
         phylo_include_seqs = os.path.join(exec_dir, config['phylo_include_seqs']),
         negative_control_prefix = config['negative_control_prefix'],
         freebayes_run = config['run_freebayes'],
-        pangolin = versions['pangolin']
+        pangolin = versions['pangolin'],
+        mode = pango_speed
     input:
         consensus = expand('{sn}/core/{sn}.consensus.fa', sn=sample_names),
         primertrimmed_bams = expand("{sn}/core/{sn}_viral_reference.mapping.primertrimmed.sorted.bam", sn=sample_names),

--- a/conda_envs/assign_lineages.yaml
+++ b/conda_envs/assign_lineages.yaml
@@ -7,6 +7,7 @@ dependencies:
   - biopython=1.74
   - minimap2>=2.16
   - pip=19.3.1
+  - setuptools<66.0.0
   - python>=3.7
   - snakemake-minimal>=5.13,<=6.8.0
   - gofasta

--- a/scripts/ncov-tools.py
+++ b/scripts/ncov-tools.py
@@ -119,7 +119,8 @@ def set_up():
 			  'negative_control_samples': f"{neg_list}",
 			  'mutation_set': 'spike_mutations',
 			  'output_directory': f"{result_dir}_ncovresults",
-			  'pangolin_version': f"'{pangolin}'"
+			  'pangolin_version': f"'{pangolin}'",
+			  'pango_analysis_mode': f"'{snakemake.params['mode']}'"
 			  }
 
 	print("Linking alignment BAMs to ncov-tools!")

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -17,7 +17,7 @@ long_git_id = '$Id: b158164f87c79271ddc9d1083e64e4be1fc26d8e $'
 
 assert long_git_id.startswith('$Id: ')
 #short_git_id = long_git_id[5:12]
-short_git_id = "v1.5.6"
+short_git_id = "v1.5.7"
 
 # Suppresses matplotlib warning (https://github.com/jaleezyy/covid-19-signal/issues/59)
 # Creates a small memory leak, but it's nontrivial to fix, and won't be a practical concern!


### PR DESCRIPTION
Python `setuptools` calls and invalid version error when generating the lineage assignment conda environment, Error resolved when restricting `setuptools` version <66.0.0.  Also adds support for ncov-tools v1.9.1. 