### PR TITLE
Lineage assignment dependency adjustment

### DIFF
--- a/conda_envs/assign_lineages.yaml
+++ b/conda_envs/assign_lineages.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pip=19.3.1
   - setuptools<66.0.0
   - python>=3.7
-  - snakemake-minimal>=5.13,<=6.8.0
+  - snakemake-minimal
   - gofasta
   - nodejs
   - usher

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -87,7 +87,7 @@ nextclade-include-recomb: True
 amplicon_loc_bed: 'resources/primer_schemes/artic_v3/ncov-qc_V3.scheme.bed'
 
 # fasta of sequences to include with pangolin phylogeny
-phylo_include_seqs: "data/blank_data.fasta"
+phylo_include_seqs: "data/blank.fasta"
 
 # List of negative control sample names or prefixes (i.e., ['Blank'] will cover Blank1, Blank2, etc.)
 negative_control_prefix: []

--- a/scripts/get_data_dependencies.sh
+++ b/scripts/get_data_dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -e # exit if pipeline returns non-zero status
-set -o pipefail # return value of last command to exit with non-zero status
+#set -e # exit if pipeline returns non-zero status
+#set -o pipefail # return value of last command to exit with non-zero status
 source ~/.bashrc
 
 if [ -z "$CONDA_EXE" ] ; then

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -17,7 +17,7 @@ long_git_id = '$Id: b158164f87c79271ddc9d1083e64e4be1fc26d8e $'
 
 assert long_git_id.startswith('$Id: ')
 #short_git_id = long_git_id[5:12]
-short_git_id = "v1.5.8"
+short_git_id = "v1.5.9"
 
 # Suppresses matplotlib warning (https://github.com/jaleezyy/covid-19-signal/issues/59)
 # Creates a small memory leak, but it's nontrivial to fix, and won't be a practical concern!

--- a/signal.py
+++ b/signal.py
@@ -238,7 +238,7 @@ if __name__ == '__main__':
 	# note: add root_dir to determine the root directory of SIGNAL
 	script_path = os.path.join(os.path.abspath(sys.argv[0]).rsplit("/",1)[0])
 	args, allowed = create_parser()
-	version = 'v1.5.8'
+	version = 'v1.5.9'
 	alt_options = []
 	
 	if args.version:


### PR DESCRIPTION
Unpinned snakemake-minimal version numbers to correspond with Pangolin dependencies. Additional tweak to bash script for initial SIGNAL dependencies to remove exit set commands. 