### PR TITLE
Better handle failing samples, add per-rule installation, and general updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ so alternatively install `mamba` and use that (snakemake has beta support for it
         conda install -c conda-forge mamba
         mamba create -c conda-forge -c bioconda -n signal snakemake pandas conda mamba
         conda activate signal
+        # mamba activate signal is equivalent
 
 Additional software dependencies are managed directly by `snakemake` using conda environment files:
 
@@ -79,31 +80,27 @@ Additional software dependencies are managed directly by `snakemake` using conda
 
 ## SIGNAL Help Screen:
 
-Using the provided `signal.py` script, the majority of SIGNAL functions can be accessed easily.
+Using the provided `signalexe.py` script, the majority of SIGNAL functions can be accessed easily.
 
 To display the help screen:
 
 ```
-python signal.py -h
+python signalexe.py -h
 
-Output:
-usage: signal.py [-h] [-c CONFIGFILE] [-d DIRECTORY] [--cores CORES] [--config-only] [--remove-freebayes] [--add-breseq]
-                 [-neg NEG_PREFIX] [--dependencies] [-ri] [--unlock] [-F] [-n] [--verbose] [-v]
-                 [all ...] [postprocess ...] [ncov_tools ...]
+usage: signalexe.py [-h] [-c CONFIGFILE] [-d DIRECTORY] [--cores CORES] [--config-only] [--remove-freebayes] [--add-breseq] [-neg NEG_PREFIX] [--dependencies] [--data DATA] [-ri] [-ii] [--unlock]
+                    [-F] [-n] [--quiet] [--verbose] [-v]
+                    [all ...] [postprocess ...] [ncov_tools ...] [install ...]
 
-SARS-CoV-2 Illumina GeNome Assembly Line (SIGNAL) aims to take Illumina short-read sequences and perform consensus assembly +
-variant calling for ongoing surveillance and research efforts towards the emergent coronavirus: Severe Acute Respiratory Syndrome
-Coronavirus 2 (SARS-CoV-2).
+SARS-CoV-2 Illumina GeNome Assembly Line (SIGNAL) aims to take Illumina short-read sequences and perform consensus assembly + variant calling for ongoing surveillance and research efforts towards
+the emergent coronavirus: Severe Acute Respiratory Syndrome Coronavirus 2 (SARS-CoV-2).
 
 positional arguments:
-  all                   Run SIGNAL with all associated assembly rules. Does not include postprocessing '--configfile' or '--
-                        directory' required. The latter will automatically generate a configuration file and sample table. If
-                        both provided, then '--configfile' will take priority
-  postprocess           Run SIGNAL postprocessing on completed SIGNAL run. '--configfile' is required but will be generated if '
-                        --directory' is provided
-  ncov_tools            Generate configuration file and filesystem setup required and then execute ncov-tools quality control
-                        assessment. Requires 'ncov-tools' submodule! '--configfile' is required but will be generated if '--
-                        directory' is provided
+  all                   Run SIGNAL with all associated assembly rules. Does not include postprocessing '--configfile' or '--directory' required. The latter will automatically generate a
+                        configuration file and sample table. If both provided, then '--configfile' will take priority
+  postprocess           Run SIGNAL postprocessing on completed SIGNAL run. '--configfile' is required but will be generated if '--directory' is provided
+  ncov_tools            Generate configuration file and filesystem setup required and then execute ncov-tools quality control assessment. Requires 'ncov-tools' submodule! '--configfile' is required
+                        but will be generated if '--directory' is provided
+  install               Install individual rule environments and ensure SIGNAL is functional. The only parameter operable will be '--data'. Will override other operations!
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -113,49 +110,57 @@ optional arguments:
                         Path to directory containing reads. Will be used to generate sample table and configuration file
   --cores CORES         Number of cores. Default = 1
   --config-only         Generate sample table and configuration file (i.e., config.yaml) and exit. '--directory' required
-  --remove-freebayes    Configuration file generator parameter. Set flag to DISABLE freebayes variant calling (improves overall
-                        speed)
-  --add-breseq          Configuration file generator parameter. Set flag to ENABLE optional breseq step (will take more time for
-                        analysis to complete)
+  --remove-freebayes    Configuration file generator parameter. Set flag to DISABLE freebayes variant calling (improves overall speed)
+  --add-breseq          Configuration file generator parameter. Set flag to ENABLE optional breseq step (will take more time for analysis to complete)
   -neg NEG_PREFIX, --neg-prefix NEG_PREFIX
-                        Configuration file generator parameter. Comma-separated list of negative sontrol sample name(s) or
-                        prefix(es). For example, 'Blank' will cover Blank1, Blank2, etc. Recommended if running ncov-tools. Will
-                        be left empty, if not provided
-  --dependencies        Download data dependencies (under a created 'data' directory) required for SIGNAL analysis and exit.
-                        Note: Will override other flags! (~10 GB storage required)
+                        Configuration file generator parameter. Comma-separated list of negative control sample name(s) or prefix(es). For example, 'Blank' will cover Blank1, Blank2, etc.
+                        Recommended if running ncov-tools. Will be left empty, if not provided
+  --dependencies        Download data dependencies (under a created 'data' directory) required for SIGNAL analysis and exit. Note: Will override other parameters! (~10 GB storage required)
+  --data DATA           SIGNAL install and data dependencies parameter. Set location for data dependancies. If '--dependancies' is run, a folder will be created in the specified directory. If '--
+                        config-only' or '--directory' is used, the value will be applied to the configuration file. (Upcoming feature): When used with 'SIGNAL install', any tests run will use the
+                        dependencies located at this directory. Default = 'data'
   -ri, --rerun-incomplete
                         Snakemake parameter. Re-run any incomplete samples from a previously failed run
+  -ii, --ignore-incomplete
+                        Snakemake parameter. Do not check for incomplete output files
   --unlock              Snakemake parameter. Remove a lock on the working directory after a failed run
   -F, --forceall        Snakemake parameter. Force the re-run of all rules regardless of prior output
   -n, --dry-run         Snakemake parameter. Do not execute anything and only display what would be done
+  --quiet               Snakemake parameter. Do not output any progress or rule information. If used with '--dry-run`, it will just display a summary of the DAG of jobs
   --verbose             Snakemake parameter. Display snakemake debugging output
   -v, --version         Display version number
 ```
 
 ## Summary:
 
-`signal.py` simplies the execution of all functions of SIGNAL. At its simplest, SIGNAL can be run with one line, provided only the directory of sequencing reads.
+`signalexe.py` simplies the execution of all functions of SIGNAL. At its simplest, SIGNAL can be run with one line, provided only the directory of sequencing reads.
 
 ```
 # Download dependances (only needs to be run once; ~10GB of storage required)
-python signal.py --dependencies
+# --data flag allows you to rename and relocate dependencies directory
+python signalexe.py --data data --dependencies
 
-# Generate configuration file and sample table (--neg_prefix can be used to note negative controls)
-python signal.py --config-only --directory /path/to/reads
+# Generate configuration file and sample table
+# --neg_prefix can be used to note negative controls
+# --data can be used to specify location of data dependencies
+python signalexe.py --config-only --directory /path/to/reads
 
 # Execute pipeline (step-by-step; --cores defaults to 1 if not provided)
-python signal.py --configfile config.yaml --cores NCORES aLL
-python signal.py --configfile config.yaml --cores NCORES postprocess
-python signal.py --configfile config.yaml --cores NCORES ncov_tools
+# --data can be used to specify location of data dependencies
+python signalexe.py --configfile config.yaml --cores NCORES all
+python signalexe.py --configfile config.yaml --cores NCORES postprocess
+python signalexe.py --configfile config.yaml --cores NCORES ncov_tools
 
 # ALTERNATIVE
 # Execute pipeline (one line)
-python signal.py --configfile config.yaml --cores NCORES all postprocess ncov_tools
+# --data can be used to specify location of data dependencies
+python signalexe.py --configfile config.yaml --cores NCORES all postprocess ncov_tools
 
 # ALTERNATIVE
 # Execute pipeline (one line; no prior configuration file or sample table steps)
 # --directory can be used in place of --configfile to automatically generate a configuration file
-python signal.py --directory /path/to/reads --cores NCORES all postprocess ncov_tools
+# --data can be used to specify location of data dependencies
+python signalexe.py --directory /path/to/reads --cores NCORES all postprocess ncov_tools
 ```
 
 Each of the steps in SIGNAL can be run **manually** by accessing the individual scripts or running snakemake.
@@ -187,8 +192,9 @@ The pipeline requires:
 - kraken2 viral database
 - Human GRCh38 reference fasta (for composite human-viral BWA index)
 
-       python signal.py --dependencies
+       python signalexe.py --dependencies
        # defaults to a directory called `data` in repository root
+       # --data can be used to rename and relocate the resultant directory
 
        OR
 
@@ -197,14 +203,24 @@ The pipeline requires:
 
 **Note: Downloading the database files requires ~10GB of storage, with up to ~35GB required for all temporary downloads!**
 
+### 1.5 Prepare per-rule conda environments:
+
+SIGNAL uses controlled conda environments for individual steps in the workflow. These are generally produced upon first execution of SIGNAL with input data; however, an option to install the per-rule environments is available through the `signalexe.py` script.
+
+       python signalexe.py install
+
+       # Will install per-rule environments
+       # Later versions of SIGNAL will include a testing module with curated data to ensure  function
+
 ### 2. Generate configuration file:
 
 You can use the `--config-only` flag to generate both `config.yaml` and `sample_table.csv` (see step 4). The directory provided will be used to auto-generate a name for the run.
 
 ```
-python signal.py --config-only --directory /path/to/reads
+python signalexe.py --config-only --directory /path/to/reads
 
 # Outputs: 'reads_config.yaml' and 'reads_sample_table.csv'
+# --data can be used to specify the location of data dependancies
 ```
 
 You can also create the configuration file through modifying the `example_config.yaml` to suit your system.
@@ -248,7 +264,7 @@ bash scripts/generate_sample_table.sh -d /path/to/more/reads -e sample_table.csv
 
 ### 4. Execute pipeline:
 
-For the main `signal.py` script, positional arguments inform the rules of the pipeline to execute with flags supplementing input parameters.
+For the main `signalexe.py` script, positional arguments inform the rules of the pipeline to execute with flags supplementing input parameters.
 
 The main rules of the pipeline are as followed:
 
@@ -258,7 +274,7 @@ The main rules of the pipeline are as followed:
 
 The generated configuration file from the above steps can be used as input. To run the general pipeline:
 
-`python signal.py --configfile config.yaml --cores 4 all`
+`python signalexe.py --configfile config.yaml --cores 4 all`
 
 is equivalent to running
 
@@ -268,7 +284,7 @@ You can run the snakemake command as written above, but note that if the `--cond
 
 Alternatively, you can skip the above configuration and sample table generation steps by simply providing the directory of reads to the main script:
 
-`python signal.py --directory /path/to/reads --cores 4 all`
+`python signalexe.py --directory /path/to/reads --cores 4 all`
 
 A configuartion file and sample table will automatically be generated prior to running SIGNAL `all`.
 
@@ -278,7 +294,7 @@ FreeBayes variant calling and BreSeq mutational analysis are technically optiona
 
 As with the general pipeline, the generated configuration file from the above steps can be used as input. To run `postprocess` which summarizes the SIGNAL results:
 
-`python signal.py --configfile config.yaml --cores 1 postprocess`
+`python signalexe.py --configfile config.yaml --cores 1 postprocess`
 
 is equivalent to running
 
@@ -306,7 +322,7 @@ Related: because pipeline stages can fail, we run (and recommend running if usin
 Additionally, SIGNAL can prepare output and execute @jts' [ncov-tools](https://github.com/jts/ncov-tools)
 to generate phylogenies and alternative summaries.
 
-`python signal.py --configfile config.yaml --cores 1 ncov_tools`
+`python signalexe.py --configfile config.yaml --cores 1 ncov_tools`
 
 is equivalent to running
 
@@ -318,17 +334,19 @@ SIGNAL will then execute ncov-tools and the **output will be found within the SI
 
 ### Multiple operations:
 
-Using `signal.py` positional arguments, you can specify SIGNAL to perform multiple rules in succession.
+Using `signalexe.py` positional arguments, you can specify SIGNAL to perform multiple rules in succession.
 
-`python signal.py --configfile config.yaml --cores NCORES all postprocess ncov_tools`
+`python signalexe.py --configfile config.yaml --cores NCORES all postprocess ncov_tools`
 
 In the above command, SIGNAL `all`, `postprocess`, and `ncov_tools` will run using the provided configuration file as input, which links to a sample table.
 
 **Note: Regardless of order for positional arguments, or placement of other parameter flags, SIGNAL will always run in the set order priority: `all` > `postprocess` > `ncov_tools`!**
 
+**Note: If `install` is provided as input, it will override all other positional arguments!**
+
 If no configuration file or sample table was generated for a run, you can provide `--directory` with the path to sequencing reads and SIGNAL will auto-generate both required inputs prior to running any rules.
 
-`python signal.py --directory /path/to/reads --cores NCORES all postprocess ncov_tools`
+`python signalexe.py --directory /path/to/reads --cores NCORES all postprocess ncov_tools`
 
 Overall, this simplifies executing SIGNAL to one line!
 
@@ -358,6 +376,44 @@ Then execute the pipeline:
 - `postprocess` and `ncov_tools` as described above generate many summaries including interactive html reports
 
 - To generate summaries of BreSeq among many samples, see [how to summarize BreSeq results using gdtools](resources/dev_scripts/summaries/README.md)
+
+### Convenient extraction script:
+
+SIGNAL produces several output files and directories on its own alongside the output for ncov-tools. Select files from the output can be copied or transferred for easier parsing using a provided convenience bash script:
+
+```
+bash scripts/get_signal_results.sh
+
+Usage:
+bash get_signal_results.sh -s <SIGNAL_results_dir> -d <destination_dir> [-m] [-c]
+
+This scripts aims to copy (rsync by default, or cp) or move (mv) select output from SIGNAL 'all', 'postprocess', and 'ncov_tools'.
+
+The following files will be transferred over to the specified destination directory (if found):
+SIGNAL 'all' & 'postprocess':
+-> signal-results/<sample>/<sample>_sample.txt
+-> signal-results/<sample>/core/<sample>.consensus.fa
+-> signal-results/<sample>/core/<sample>_ivar_variants.tsv
+-> signal-results/<sample>/freebayes/<sample>.consensus.fasta
+-> signal-results/<sample>/freebayes/<sample>.variants.norm.vcf
+
+SIGNAL 'ncov_tools':
+-> ncov_tools-results/qc_annotation/<sample>.ann.vcf
+-> ncov-tools-results/qc_reports/<run_name>_ambiguous_position_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_mixture_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_ncov_watch_variants.tsv
+-> ncov-tools-results/qc_reports/<run_name>_negative_control_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_summary_qc.tsv
+
+Flags:
+        -s  :  SIGNAL results directory
+        -d  :  Directory where summary will be outputted
+        -m  :  Invoke 'mv' move command instead of 'rsync' copying of results. Optional
+        -c  :  Invoke 'cp' copy command instead of 'rsync' copying of results. Optional
+
+```
+
+The script uses `rsync` to provide accurate copies of select output files organized into `signal-results` and `ncov-tools-results` within a provided destination directory (that must exist). If the `-c` is provided, `cp` will be used instead of `rsync` to produce copies. Similarly, if `-m` is provided, `mv` will be used instead (**WARNING: Any interruption during `mv` could result in data loss.**)
 
 ## Pipeline details:
 

--- a/README.md
+++ b/README.md
@@ -203,18 +203,18 @@ The pipeline requires:
 
 **Note: Downloading the database files requires ~10GB of storage, with up to ~35GB required for all temporary downloads!**
 
-### 1.5 Prepare per-rule conda environments:
+### 1.5. Prepare per-rule conda environments (optional, but recommended):
 
 SIGNAL uses controlled conda environments for individual steps in the workflow. These are generally produced upon first execution of SIGNAL with input data; however, an option to install the per-rule environments is available through the `signalexe.py` script.
 
        python signalexe.py install
 
        # Will install per-rule environments
-       # Later versions of SIGNAL will include a testing module with curated data to ensure  function
+       # Later versions of SIGNAL will include a testing module with curated data to ensure function
 
 ### 2. Generate configuration file:
 
-You can use the `--config-only` flag to generate both `config.yaml` and `sample_table.csv` (see step 4). The directory provided will be used to auto-generate a name for the run.
+You can use the `--config-only` flag to generate both `config.yaml` and `sample_table.csv`. The directory provided will be used to auto-generate a name for the run.
 
 ```
 python signalexe.py --config-only --directory /path/to/reads
@@ -231,7 +231,7 @@ You can also create the configuration file through modifying the `example_config
 
 See the example table `example_sample_table.csv` for an idea of how to organise this table.
 
-**Using the `--config-only` flag, both configuration file and sample table will be generated (see above in step 3) from a given directory path to reads.**
+**Using the `--config-only` flag, both configuration file and sample table will be generated (see above in step 2) from a given directory path to reads.**
 
 Alternatively, you can attempt to use `generate_sample_table.sh` to circumvent manual creation of the table.
 
@@ -282,7 +282,7 @@ is equivalent to running
 
 You can run the snakemake command as written above, but note that if the `--conda-prefix` is not set as this (i.e., `$PWD/.snakemake/conda`), then all envs will be reinstalled for each time you change the `results_dir` in the `config.yaml`.
 
-Alternatively, you can skip the above configuration and sample table generation steps by simply providing the directory of reads to the main script:
+Alternatively, you can skip the above configuration and sample table generation steps by simply providing the directory of reads to the main script (see step 2):
 
 `python signalexe.py --directory /path/to/reads --cores 4 all`
 

--- a/Snakefile
+++ b/Snakefile
@@ -242,7 +242,8 @@ rule ncov_tools:
         negative_control_prefix = config['negative_control_prefix'],
         freebayes_run = config['run_freebayes'],
         pangolin = versions['pangolin'],
-        mode = pango_speed
+        mode = pango_speed,
+        failed = os.path.join(result_dir, 'failed_samples.log') 
     input:
         consensus = expand('{sn}/core/{sn}.consensus.fa', sn=sample_names),
         primertrimmed_bams = expand("{sn}/core/{sn}_viral_reference.mapping.primertrimmed.sorted.bam", sn=sample_names),

--- a/Snakefile
+++ b/Snakefile
@@ -129,21 +129,25 @@ rule clean_reads:
 rule consensus:
     input: expand('{sn}/core/{sn}.consensus.fa', sn=sample_names)
 
+rule core_genomes:
+    input: 'all_genomes.fa'
+
 rule ivar_variants:
     input: expand('{sn}/core/{sn}_ivar_variants.tsv', sn=sample_names)
 
 rule breseq:
     input: expand('{sn}/breseq/output/index.html', sn=sample_names)
 
+
 rule freebayes:
-    input: 
+    input:
+        'all_freebayes_genomes.fa',
         expand('{sn}/freebayes/{sn}.consensus.fasta', sn=sample_names),
         expand('{sn}/freebayes/{sn}.variants.norm.vcf', sn=sample_names),
         'freebayes_lineage_assignments.tsv',
         expand('{sn}/freebayes/quast/{sn}_quast_report.html', sn=sample_names),
         expand('{sn}/freebayes/{sn}_consensus_compare.vcf', sn=sample_names)
 
-    
 rule coverage:
     input: expand('{sn}/coverage/{sn}_depth.txt', sn=sample_names)
 
@@ -158,6 +162,7 @@ rule quast:
 
 rule lineages:
     input:
+        rules.core_genomes.input,
         'input_pangolin_versions.txt',
         'input_nextclade_versions.txt',
         'lineage_assignments.tsv'
@@ -769,6 +774,9 @@ rule run_quast_freebayes:
          'quast {input} -r {params.genome} -g {params.fcoords} --output-dir {params.outdir} --threads {threads} >{log} && '
          'for f in {params.unlabelled_reports}; do mv $f ${{f/report/{params.sample_name}}}; done'
 
+rule collect_core_genomes:
+    
+
 rule run_lineage_assignment:
     threads: 4
     conda: 'conda_envs/assign_lineages.yaml'
@@ -796,6 +804,9 @@ rule run_lineage_assignment:
         "echo -e 'nextclade: {params.nextclade_ver}\nnextclade-dataset: {params.nextclade_data}\nnextclade-include-recomb: {params.nextclade_recomb}' > {output.nextclade_ver_out} && "
         'cat {input} > all_genomes.fa && '
         '{params.assignment_script_path} -i all_genomes.fa -t {threads} -o {output.lin_out} -p {output.pango_ver_out} -n {output.nextclade_ver_out} --mode {params.analysis_mode}'
+
+rule collect_freebayes_genomes:
+    
 
 rule run_lineage_assignment_freebayes:
     threads: 4

--- a/Snakefile
+++ b/Snakefile
@@ -243,7 +243,7 @@ rule ncov_tools:
         freebayes_run = config['run_freebayes'],
         pangolin = versions['pangolin'],
         mode = pango_speed,
-        failed = os.path.join(result_dir, 'failed_samples.log') 
+        failed = 'failed_samples.log'
     input:
         consensus = expand('{sn}/core/{sn}.consensus.fa', sn=sample_names),
         primertrimmed_bams = expand("{sn}/core/{sn}_viral_reference.mapping.primertrimmed.sorted.bam", sn=sample_names),

--- a/conda_envs/assign_lineages.yaml
+++ b/conda_envs/assign_lineages.yaml
@@ -11,7 +11,6 @@ dependencies:
   - python>=3.7
   - snakemake-minimal
   - gofasta
-  - nodejs
   - usher
   - pandas
   - pysam==0.16.0.1

--- a/resources/dependencies
+++ b/resources/dependencies
@@ -4,8 +4,8 @@ rule all:
         "ivar",
         "snp_mapping",
         "trim_qc",
-        "assign_lineages.yaml",
-        "freebayes.yaml",
+        "assign_lineages",
+        "freebayes",
         "postprocessing"
     shell: "rm {input}"
 

--- a/resources/dependencies
+++ b/resources/dependencies
@@ -4,6 +4,8 @@ rule all:
         "ivar",
         "snp_mapping",
         "trim_qc",
+        "assign_lineages.yaml",
+        "freebayes.yaml",
         "postprocessing"
     shell: "rm {input}"
 
@@ -25,6 +27,16 @@ rule snp_mapping:
 rule trim_qc:
     conda: "../conda_envs/trim_qc.yaml"
     output: "trim_qc"
+    shell: "touch {output}"
+
+rule assign_lineages:
+    conda: "../conda_envs/assign_lineages.yaml"
+    output: "assign_lineages"
+    shell: "touch {output}"
+
+rule freebayes:
+    conda: "../conda_envs/freebayes.yaml"
+    output: "freebayes"
     shell: "touch {output}"
 
 rule postprocessing:

--- a/scripts/assign_lineages.py
+++ b/scripts/assign_lineages.py
@@ -8,6 +8,7 @@ import pandas as pd
 import shutil
 import os, sys
 from datetime import datetime
+import json
 
 
 def check_file(path: str) -> Path:
@@ -136,27 +137,53 @@ def update_nextclade_dataset(vers, skip):
 
 	# If specific tag requested, attempt to install, otherwise install latest
 	accession = 'MN908947'
+	current_tag = None
+	if os.path.exists(os.path.join(output_dir, 'tag.json')):
+		j = open(os.path.join(output_dir, 'tag.json'))
+		data = json.load(j)
+		current_tag = data['tag']
+		j.close()
 	if requested is not None:
+		# check existing database, if found
+			if requested == current_tag:
+				print(f"Nextclade dataset {requested} already installed! Skipping update!")
+			else:
+				try:
+					print(f"\nDownloading Nextclade {dataset} dataset tagged {requested} for reference {accession}!")
+					subprocess.run(f"nextclade dataset get "
+								f"--name '{dataset}' "
+								f"--reference '{accession}' "
+								f"--tag {requested} "
+								f"--output-dir '{output_dir}'", shell=True, check=True)
+				except subprocess.CalledProcessError:
+					print(f"\nDatabase not found! Please check whether {requested} tag exists! Downloading latest Nextclade {dataset} dataset for reference {accession}...")
+					try:
+						subprocess.run(f"nextclade dataset get "
+									f"--name '{dataset}' "
+									f"--reference '{accession}' "
+									f"--output-dir '{output_dir}'", shell=True, check=True)
+					except subprocess.CalledProcessError:
+						if current_tag is not None:
+							print(f"Something went wrong updating the Nextclade dataset, using {current_tag} instead!")
+							requested = current_tag
+						else:
+							print(f"Something went wrong updating the Nextclade dataset! No database could be found which may result in errors! Skipping update...")
+							requested = "Unknown"
+	else:
 		try:
-			print(f"\nDownloading Nextclade {dataset} dataset tagged {requested} for reference {accession}!")
+			print(f"\nDownloading latest Nextclade {dataset} dataset for reference {accession}!")
 			subprocess.run(f"nextclade dataset get "
 						f"--name '{dataset}' "
 						f"--reference '{accession}' "
-						f"--tag {requested} "
 						f"--output-dir '{output_dir}'", shell=True, check=True)
 		except subprocess.CalledProcessError:
-			print(f"\nDatabase not found! Please check whether {requested} tag exists! Downloading latest Nextclade {dataset} dataset for reference {accession}...")
-			subprocess.run(f"nextclade dataset get "
-						f"--name '{dataset}' "
-						f"--reference '{accession}' "
-						f"--output-dir '{output_dir}'", shell=True, check=True)
-	else:
-		print(f"\nDownloading latest Nextclade {dataset} dataset for reference {accession}!")
-		subprocess.run(f"nextclade dataset get "
-					f"--name '{dataset}' "
-					f"--reference '{accession}' "
-					f"--output-dir '{output_dir}'", shell=True, check=True)
-
+			if current_tag is not None:
+				print(f"Something went wrong updating the Nextclade dataset, using {current_tag} instead!")
+				requested = current_tag
+			else:
+				print(f"Something went wrong updating the Nextclade dataset! No database could be found which may result in errors! Skipping update...")
+				requested = "Unknown"
+	
 	# Obtain final version information for output
 	nextclade_version = subprocess.run(f"nextclade --version".split(), stdout=subprocess.PIPE).stdout.decode('utf-8').strip().lower()
 	if nextclade_version.startswith("nextclade"):

--- a/scripts/get_data_dependencies.sh
+++ b/scripts/get_data_dependencies.sh
@@ -14,34 +14,42 @@ accession="MN908947.3"
 
 HELP="""
 Flags:
-    -d  :  Directory to configure database within (~10GB)
-    -a  :  Accession to use as viral reference (default=MN908947.3)
+	-d  :  Directory to configure database within (~10GB)
+	-a  :  Accession to use as viral reference (default=MN908947.3)
 """
 
 while getopts ":d:a:" option; do
-    case "${option}" in
-        d) database_dir=$OPTARG;;
-        a) accession=$OPTARG;;
-    esac
+	case "${option}" in
+		d) database_dir=$OPTARG;;
+		a) accession=$OPTARG;;
+	esac
 done
 
 if [ $database_dir = 0 ] ; then
-    echo "You must specify a data directory to install data dependencies."
-    echo "$HELP"
-    exit 1
+	echo "You must specify a data directory to install data dependencies."
+	echo "$HELP"
+	exit 1
 fi
 
 echo -e "Warning: \n - final databases require ~10GB of storage\n - building databases temporarily requires a peak of ~35GB of storage and ~4GB of memory \n - script takes up to ~1.5 hours (system depending)"
 
 # make database dir and get abspath to it
-mkdir -p $database_dir
+if [ ! -d $database_dir ]; then mkdir -p $database_dir; fi
 database_dir=$(realpath $database_dir)
 
 # use curl to grab "simple data dependencies"
-curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
-curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
-curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
-curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
+if [ ! -f $database_dir/'NexteraPE-PE.fa' ]; then
+	curl -s "https://raw.githubusercontent.com/timflutre/trimmomatic/3694641a92d4dd9311267fed85b05c7a11141e7c/adapters/NexteraPE-PE.fa" > $database_dir/NexteraPE-PE.fa
+fi
+if [ ! -f $database_dir/${accession}.gbk ]; then
+	curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=gb&retmode=txt" > $database_dir/$accession.gbk
+fi
+if [ ! -f $database_dir/${accession}.gff3 ]; then
+	curl -s "https://www.ncbi.nlm.nih.gov/sviewer/viewer.cgi?db=nuccore&report=gff3&id=${accession}" > $database_dir/$accession.gff3
+fi
+if [ ! -f $database_dir/${accession}.fasta ]; then
+	curl -s "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nucleotide&id=${accession}&rettype=fasta&retmode=txt" > $database_dir/$accession.fasta
+fi
 
 # install and activate env for kraken/bwa to build their databases/index
 CONDA_BASE=$($CONDA_EXE info --base)
@@ -51,19 +59,37 @@ conda activate data_dependencies
 
 # get the GRCh38 human genome
 # as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use
-curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > $database_dir/GRC38_no_alt_analysis_set.fna.gz
-gunzip $database_dir/GRC38_no_alt_analysis_set.fna.gz
+if [ ! -f $database_dir/"GRC38_no_alt_analysis_set.fna" ]; then
+	curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > $database_dir/GRC38_no_alt_analysis_set.fna.gz
+	gunzip $database_dir/GRC38_no_alt_analysis_set.fna.gz
+fi
 
 # create composite reference of human and virus for competitive bwt mapping 
 # based host removal
+if [ ! -f $database_dir/'composite_human_viral_reference.fna' ]; then
 cat $database_dir/GRC38_no_alt_analysis_set.fna $database_dir/$accession.fasta > $database_dir/composite_human_viral_reference.fna
-bwa index $database_dir/composite_human_viral_reference.fna
+fi
+for file in $database_dir/composite_human_viral_reference.fna.{amb,ann,bwt,pac,sa}; do
+	if [ ! -f $file ]; then
+		bwa index $database_dir/composite_human_viral_reference.fna
+		break
+	else
+		continue
+	fi
+done
 
 # get kraken2 viral db
 mkdir -p $database_dir/Kraken2/db
-curl -s "https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20210517.tar.gz" > $database_dir/Kraken2/db/k2_viral_20210517.tar.gz
-cd $database_dir/Kraken2/db
-tar xvf k2_viral_20210517.tar.gz
+for file in $database_dir/Kraken2/db/{hash,opts,taxo}.k2d; do
+	if [ ! -f $file ]; then
+		curl -s "https://genome-idx.s3.amazonaws.com/kraken/k2_viral_20210517.tar.gz" > $database_dir/Kraken2/db/k2_viral_20210517.tar.gz
+		cd $database_dir/Kraken2/db
+		tar xvf k2_viral_20210517.tar.gz
+		break
+	else
+		continue
+	fi
+done
 
 # create blank fasta for 'phylo_include_seqs'
 touch $database_dir/blank.fasta

--- a/scripts/get_signal_results.sh
+++ b/scripts/get_signal_results.sh
@@ -11,7 +11,7 @@ HELP="""
 Usage:
 bash get_signal_results.sh -s <SIGNAL_results_dir> -d <destination_dir> [-m] [-c]
 
-This scripts aims to copy (rsync by default) or move (mv) select output from SIGNAL 'all', 'postprocess', and 'ncov_tools'.
+This scripts aims to copy (rsync by default, or cp) or move (mv) select output from SIGNAL 'all', 'postprocess', and 'ncov_tools'.
 
 The following files will be transferred over to the specified destination directory (if found):
 SIGNAL 'all' & 'postprocess':

--- a/scripts/get_signal_results.sh
+++ b/scripts/get_signal_results.sh
@@ -5,14 +5,15 @@ shopt -s extglob
 source=0
 destination=0
 move='false'
+copy='false'
 
 HELP="""
 Usage:
-bash get_signal_results.sh -s <SIGNAL_results_dir> -d <destination_dir> [-m]
+bash get_signal_results.sh -s <SIGNAL_results_dir> -d <destination_dir> [-m] [-c]
 
 This scripts aims to copy (rsync by default) or move (mv) select output from SIGNAL 'all', 'postprocess', and 'ncov_tools'.
 
-The following files will be transferred over to the specified  destination directory (if found):
+The following files will be transferred over to the specified destination directory (if found):
 SIGNAL 'all' & 'postprocess':
 -> signal-results/<sample>/<sample>_sample.txt
 -> signal-results/<sample>/core/<sample>.consensus.fa
@@ -20,7 +21,7 @@ SIGNAL 'all' & 'postprocess':
 -> signal-results/<sample>/freebayes/<sample>.consensus.fasta
 -> signal-results/<sample>/freebayes/<sample>.variants.norm.vcf
 
-'ncov_tools':
+SIGNAL 'ncov_tools':
 -> ncov_tools-results/qc_annotation/<sample>.ann.vcf
 -> ncov-tools-results/qc_reports/<run_name>_ambiguous_position_report.tsv
 -> ncov-tools-results/qc_reports/<run_name>_mixture_report.tsv
@@ -31,14 +32,16 @@ SIGNAL 'all' & 'postprocess':
 Flags:
 	-s  :  SIGNAL results directory
 	-d  :  Directory where summary will be outputted
-	-m  :  Invoke 'mv' command instead of 'rsync' copying of results. Optional
+	-m  :  Invoke 'mv' move command instead of 'rsync' copying of results. Optional
+	-c  :  Invoke 'cp' copy command instead of 'rsync' copying of results. Optional
 """
 
-while getopts ":s:d:m" option; do
+while getopts ":s:d:mc" option; do
 	case "${option}" in
 		s) source=$OPTARG;;
 		d) destination=$OPTARG;;
 		m) move='true';;
+		c) copy='true';;
 	esac
 done
 
@@ -63,8 +66,13 @@ else
 	mkdir -p $final_dir/signal-results
 fi
 	
-if ${move}; then
+if [ ${move} = true ] && [ ${copy} = true ]; then
+	echo -e "Only pick one of '-m' or '-c' depending on whether you wish to move or copy files, respectively"
+	exit
+elif [ ${move} = true ] && [ ${copy} = false ]; then
 	cmd='mv'
+elif [ ${move} = false ] && [ ${copy} = true ]; then
+	cmd='cp'
 else
 	cmd='rsync -avh'
 	# rsync -avh

--- a/scripts/get_signal_results.sh
+++ b/scripts/get_signal_results.sh
@@ -1,0 +1,114 @@
+#!/bin/env bash
+
+shopt -s extglob
+
+source=0
+destination=0
+move='false'
+
+HELP="""
+Usage:
+bash get_signal_results.sh -s <SIGNAL_results_dir> -d <destination_dir> [-m]
+
+This scripts aims to copy (rsync by default) or move (mv) select output from SIGNAL 'all', 'postprocess', and 'ncov_tools'.
+
+The following files will be transferred over to the specified  destination directory (if found):
+SIGNAL 'all' & 'postprocess':
+-> signal-results/<sample>/<sample>_sample.txt
+-> signal-results/<sample>/core/<sample>.consensus.fa
+-> signal-results/<sample>/core/<sample>_ivar_variants.tsv
+-> signal-results/<sample>/freebayes/<sample>.consensus.fasta
+-> signal-results/<sample>/freebayes/<sample>.variants.norm.vcf
+
+'ncov_tools':
+-> ncov_tools-results/qc_annotation/<sample>.ann.vcf
+-> ncov-tools-results/qc_reports/<run_name>_ambiguous_position_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_mixture_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_ncov_watch_variants.tsv
+-> ncov-tools-results/qc_reports/<run_name>_negative_control_report.tsv
+-> ncov-tools-results/qc_reports/<run_name>_summary_qc.tsv
+
+Flags:
+	-s  :  SIGNAL results directory
+	-d  :  Directory where summary will be outputted
+	-m  :  Invoke 'mv' command instead of 'rsync' copying of results. Optional
+"""
+
+while getopts ":s:d:m" option; do
+	case "${option}" in
+		s) source=$OPTARG;;
+		d) destination=$OPTARG;;
+		m) move='true';;
+	esac
+done
+
+
+if [ $source = 0 ] || [ $destination = 0 ] ; then
+	echo "You must specify both source and destination locations."
+	echo "$HELP"
+	exit 1
+fi
+
+if [ ! -d $destination ]; then
+	echo "Invalid destination directory!"
+	exit 1
+fi
+
+if [ ! -f $source/summary.html ] && [ ! -f $source/summary.zip ]; then
+	echo "Invalid SIGNAL directory! Make sure you've run SIGNAL 'all' and 'postprocess'!"
+	exit 1
+else
+	run_name=$(basename $source)
+	final_dir=${destination}/${run_name}
+	mkdir -p $final_dir/signal-results
+fi
+	
+if ${move}; then
+	cmd='mv'
+else
+	cmd='rsync -avh'
+	# rsync -avh
+fi
+
+echo -e "We will use ${cmd} for your files!"
+
+### SIGNAL results_dir
+for file in $source/*; do 
+	if [ -d $file ]; then # results_dir/sample
+		sample=$(basename $file) # sample name, within contain our files
+		sample_dest=${final_dir}/'signal-results'/${sample}
+		if [[ ! $sample == 'ncov-tools-results' ]]; then
+			mkdir -p $sample_dest
+		fi
+		for d in $file/*; do
+			name=$(basename $d)
+			if [ -d $d ] && [[ $name == 'core' ]]; then
+				mkdir -p $sample_dest/core
+				$cmd ${d}/${sample}.consensus.fa $sample_dest/core/${sample}.consensus.fa
+				$cmd ${d}/${sample}_ivar_variants.tsv $sample_dest/core/${sample}_ivar_variants.tsv
+			elif [ -d $d ] && [[ $name == 'freebayes' ]]; then
+				mkdir -p $sample_dest/freebayes
+				$cmd ${d}/${sample}.consensus.fasta $sample_dest/freebayes/${sample}.consensus.fasta 
+				$cmd ${d}/${sample}.variants.norm.vcf $sample_dest/freebayes/${sample}.variants.norm.vcf
+			elif [ -f $d ] && [[ $name =~ '_sample.txt' ]]; then
+				$cmd ${d} $sample_dest/$(basename $d)
+			else
+				continue
+			fi
+		done
+	fi
+done
+
+echo "Files from SIGNAL transferred!"
+
+### NCOV-TOOLS
+if [ ! -d $source/ncov-tools-results ]; then
+	echo "No ncov-tools-results directory found!"
+else
+	ncov_dest=${final_dir}/ncov-tools-results
+	mkdir -p $ncov_dest/qc_{annotation,reports}
+	$cmd $source/ncov-tools-results/qc_reports/* $ncov_dest/qc_reports
+	$cmd $source/ncov-tools-results/qc_annotation/*.ann.vcf  $ncov_dest/qc_annotation
+	
+	echo "Files from ncov-tools transferred!"
+fi

--- a/scripts/ncov-tools.py
+++ b/scripts/ncov-tools.py
@@ -182,7 +182,7 @@ def set_up():
 		for key, value in config.items():
 			fh.write(f"{key}: {value}\n")
 			
-	return exec_dir, result_dir
+	return exec_dir, result_dir, data_root
 
 def run_all():
 	os.system(f"snakemake -s workflow/Snakefile --cores {snakemake.threads} all")
@@ -221,12 +221,14 @@ def move(cwd, dest, prefix):
 		print("Missing ncov-tools 'qc_analysis' directory")
 
 if __name__ == '__main__':
-	exec_dir, result_dir = set_up()
+	exec_dir, result_dir, data_root = set_up()
 	run_script = os.path.join(exec_dir, 'scripts', 'run_ncov_tools.sh')
 	#print("Don't forget to update the config.yaml file as needed prior to running ncov-tools.")
 	print("Running ncov-tools using %s cores!" %(snakemake.threads))
 
 	subprocess.run([run_script, '-c', str(snakemake.threads), '-s', str(result_dir)])
-
+	
+	# clean up
+	shutil.rmtree(data_root)
 	#run_all()
 	#move(exec_dir, result_root, result_dir)

--- a/scripts/ncov-tools.py
+++ b/scripts/ncov-tools.py
@@ -6,17 +6,21 @@ import subprocess
 import fileinput
 import glob
 
-def link_ivar(root, replace=False):
+def link_ivar(root, replace=False, neg, failed):
 	print("Linking iVar files to ncov-tools!")
 
 	for variants in snakemake.input['variants']:
 		sample = variants.split('/')[0]
+		if (sample in failed) and (sample not in neg):
+			continue
 		ln_path = f"{root}/{sample}.variants.tsv"
 		if (not os.path.exists(ln_path)) or (replace is True):
 			os.link(variants, ln_path)
 
 	for consensus in snakemake.input['consensus']:
 		sample = consensus.split('/')[0]
+		if (sample in failed) and (sample not in neg):
+			continue
 		ln_path = f"{root}/{sample}.consensus.fasta"
 		if (not os.path.exists(ln_path)) or (replace is True):
 			os.link(consensus, ln_path)
@@ -30,15 +34,17 @@ def link_ivar(root, replace=False):
 
 # take sample name from iVar results, redirect to where corresponding FreeBayes should be
 # if FreeBayes file cannot be found, break from loop, replace all with iVar
-def link_freebayes(root):
+def link_freebayes(root, neg, failed):
 	print("Linking FreeBayes files to ncov-tools!")
 
 	for variants in snakemake.input['variants']:
 		sample = variants.split('/')[0]
+		if (sample in failed) and (sample not in neg):
+			continue
 		expected_path = os.path.join(sample, 'freebayes', sample+'.variants.norm.vcf')
 		if not os.path.exists(expected_path):
 			print("Missing FreeBayes variant file! Switching to iVar input!")
-			link_ivar(root, True)
+			link_ivar(root, True, neg, failed)
 			break
 		else:
 			ln_path = f"{root}/{sample}.variants.vcf"
@@ -47,10 +53,12 @@ def link_freebayes(root):
 
 	for consensus in snakemake.input['consensus']:
 		sample = consensus.split('/')[0]
+		if (sample in failed) and (sample not in neg):
+			continue
 		expected_path = os.path.join(sample, 'freebayes', sample+'.consensus.fasta')
 		if not os.path.exists(expected_path):
 			print("Missing FreeBayes variant file! Switching to iVar input!")
-			link_ivar(root, True)
+			link_ivar(root, True, neg, failed)
 			break
 		else:
 			ln_path = f"{root}/{sample}.consensus.fasta"
@@ -99,6 +107,12 @@ def set_up():
 	neg_list = list(neg_samples)
 	print("Negative control samples found include: %s" %(neg_list))
 
+### Pull failed samples (SIGNAL log file: failed_samples.log)
+	if os.path.exists(snakemake.params['failed']):
+		with open(snakemake.params['failed']) as fail:
+			failed_list = [i.strip() for i in fail.readlines()[1:]]
+	else:
+		failed_list = []
 
 ### config.yaml parameters
 	config = {'data_root': f"'{data_root}'",
@@ -126,21 +140,26 @@ def set_up():
 	print("Linking alignment BAMs to ncov-tools!")
 	for bam in snakemake.input['bams']:
 		sample = bam.split('/')[0]
+		# if sample failed and not a negative, skip linking
+		if (sample in failed_list) and (sample not in neg_list):
+			continue
 		ln_path = f"{data_root}/{sample}.bam"
-		if (not os.path.exists(ln_path)) or (replace is True):
+		if not os.path.exists(ln_path):
 			os.link(bam, ln_path)
 
 	for primer_trimmed_bam in snakemake.input['primertrimmed_bams']:
 		sample = primer_trimmed_bam.split('/')[0]
+		if (sample in failed_list) and (sample not in neg_list):
+			continue
 		ln_path = f"{data_root}/{sample}.mapped.primertrimmed.sorted.bam"
-		if (not os.path.exists(ln_path)) or (replace is True):
+		if not os.path.exists(ln_path):
 			os.link(primer_trimmed_bam, ln_path)
 			
 	if snakemake.params['freebayes_run']:
-		link_freebayes(data_root)
+		link_freebayes(data_root, neg_list, failed_list)
 		config['variants_pattern'] = "'{data_root}/{sample}.variants.vcf'"
 	else:
-		link_ivar(data_root)
+		link_ivar(data_root, neg_list, failed_list)
 
 	with open(os.path.join(exec_dir, 'ncov-tools', 'config.yaml'), 'w') as fh:
 		for key, value in config.items():

--- a/scripts/ncov-tools.py
+++ b/scripts/ncov-tools.py
@@ -83,10 +83,26 @@ def set_up():
 	try:
 		assert pangolin == "3" or pangolin == "4" # directly supported versions
 	except AssertionError:
-		import urllib.request as web
-		commit_url = web.urlopen(f"https://github.com/cov-lineages/pangolin/releases/latest").geturl()
-		pangolin = commit_url.split("/")[-1].split(".")[0].lower().strip("v") 
+		# import urllib.request as web
+		# commit_url = web.urlopen(f"https://github.com/cov-lineages/pangolin/releases/latest").geturl()
+		# pangolin = commit_url.split("/")[-1].split(".")[0].lower().strip("v") 
 		# latest version (should ensure temporary compatibility)
+		installed_versions = subprocess.run(["pangolin", "--all-versions"],
+								check=True,
+								stdout=subprocess.PIPE)
+		installed_versions = installed_versions.stdout.decode('utf-8')
+		installed_ver_dict = {}
+		for dep_ver in map(str.strip, installed_versions.split('\n')):
+		# skip empty line at end
+			if len(dep_ver) == 0:
+				continue
+			try:
+				dependency, version = dep_ver.split(': ')
+			except ValueError:
+				continue
+			if dependency == 'pangolin':
+				pangolin = str(version).split(".",1)[0].strip('v')
+				break
 
 ### Create data directory within ncov-tools
 	data_root = os.path.abspath(os.path.join(exec_dir, 'ncov-tools', "%s" %(result_dir)))

--- a/scripts/ncov-tools.py
+++ b/scripts/ncov-tools.py
@@ -6,7 +6,7 @@ import subprocess
 import fileinput
 import glob
 
-def link_ivar(root, replace=False, neg, failed):
+def link_ivar(root, neg, failed, replace=False):
 	print("Linking iVar files to ncov-tools!")
 
 	for variants in snakemake.input['variants']:
@@ -44,7 +44,7 @@ def link_freebayes(root, neg, failed):
 		expected_path = os.path.join(sample, 'freebayes', sample+'.variants.norm.vcf')
 		if not os.path.exists(expected_path):
 			print("Missing FreeBayes variant file! Switching to iVar input!")
-			link_ivar(root, True, neg, failed)
+			link_ivar(root, neg, failed, replace=True)
 			break
 		else:
 			ln_path = f"{root}/{sample}.variants.vcf"
@@ -58,7 +58,7 @@ def link_freebayes(root, neg, failed):
 		expected_path = os.path.join(sample, 'freebayes', sample+'.consensus.fasta')
 		if not os.path.exists(expected_path):
 			print("Missing FreeBayes variant file! Switching to iVar input!")
-			link_ivar(root, True, neg, failed)
+			link_ivar(root, neg, failed, replace=True)
 			break
 		else:
 			ln_path = f"{root}/{sample}.consensus.fasta"
@@ -113,6 +113,7 @@ def set_up():
 			failed_list = [i.strip() for i in fail.readlines()[1:]]
 	else:
 		failed_list = []
+	print("Failed samples found include: %s" %(failed_list))
 
 ### config.yaml parameters
 	config = {'data_root': f"'{data_root}'",
@@ -159,7 +160,7 @@ def set_up():
 		link_freebayes(data_root, neg_list, failed_list)
 		config['variants_pattern'] = "'{data_root}/{sample}.variants.vcf'"
 	else:
-		link_ivar(data_root, neg_list, failed_list)
+		link_ivar(data_root, neg_list, failed_list, replace=False)
 
 	with open(os.path.join(exec_dir, 'ncov-tools', 'config.yaml'), 'w') as fh:
 		for key, value in config.items():

--- a/scripts/run_ncov_tools.sh
+++ b/scripts/run_ncov_tools.sh
@@ -35,9 +35,9 @@ if [ $1 = 'help' ]; then
 fi
 
 if [ $SIGNAL = 0 ] ; then
-    echo "You must specify the name of the directory holding SIGNAL results."
-    echo "$HELP"
-    exit 1
+	echo "You must specify the name of the directory holding SIGNAL results."
+	echo "$HELP"
+	exit 1
 fi
 
 # Start point for executing from ncov-tools.py is SIGNAL results directory

--- a/scripts/run_ncov_tools.sh
+++ b/scripts/run_ncov_tools.sh
@@ -50,7 +50,7 @@ cd ../ncov-tools
 # run ncov-tools
 snakemake -k -s workflow/Snakefile --cores ${CORES} all
 
-# move ncovresults to SIGNAL results directory
+# move ncovresults to SIGNAL results directory and clean up
 mv ${SIGNAL}'_ncovresults' ${RESULTS}/ncov-tools-results
 
 # return success

--- a/scripts/run_ncov_tools.sh
+++ b/scripts/run_ncov_tools.sh
@@ -48,7 +48,7 @@ RESULTS=$PWD
 cd ../ncov-tools
 
 # run ncov-tools
-snakemake -s workflow/Snakefile --cores ${CORES} all
+snakemake -k -s workflow/Snakefile --cores ${CORES} all
 
 # move ncovresults to SIGNAL results directory
 mv ${SIGNAL}'_ncovresults' ${RESULTS}/ncov-tools-results

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -17,7 +17,7 @@ long_git_id = '$Id: b158164f87c79271ddc9d1083e64e4be1fc26d8e $'
 
 assert long_git_id.startswith('$Id: ')
 #short_git_id = long_git_id[5:12]
-short_git_id = "v1.5.9"
+short_git_id = "v1.6.0"
 
 # Suppresses matplotlib warning (https://github.com/jaleezyy/covid-19-signal/issues/59)
 # Creates a small memory leak, but it's nontrivial to fix, and won't be a practical concern!

--- a/signalexe.py
+++ b/signalexe.py
@@ -120,7 +120,8 @@ def check_submodule(exec_dir):
 			print("Updating ncov-tools!")
 			subprocess.run(['git', 'submodule', 'update', '--init', '--recursive'])
 		except subprocess.CalledProcessError:
-			exit("Could not find nor update the required 'ncov-tools' directory! Manually download/update and try again!")
+			print("Could not find nor update the required 'ncov-tools' directory! Manually download/update and try again!")
+			sys.exit(1)
 		
 def write_sample_table(sample_data, output_table):
 	"""
@@ -252,7 +253,8 @@ def install_signal(frontend, data='data'):
 	try:
 		subprocess.run(f"snakemake -s {dep_snakefile} --conda-frontend {frontend} --cores 1 --use-conda --conda-prefix=$PWD/.snakemake/conda --quiet", shell=True, check=True)
 	except subprocess.CalledProcessError: 
-		exit("Installation of environments failed!")
+		print("Installation of environments failed!")
+		sys.exit(1)
 	
 	### TODO: Test SIGNAL with curated data
 	if os.path.exists(data):
@@ -267,21 +269,26 @@ if __name__ == '__main__':
 	alt_options = []
 	
 	if args.version:
-		exit(f"{version}")
+		print(f"{version}")
+		sys.exit(0)
 	
 	conda_frontend = check_frontend() # 'mamba' or 'conda'
 	
 	if allowed['install']:
 		install_signal(conda_frontend, args.data)
-		exit("Installation of environments completed successfully!")
+		print("Installation of environments completed successfully!")
+		sys.exit(0)
 	
 	if args.dependencies:
 		print("Downloading necessary reference and dependency files!")
 		download_dependences(args.data)
-		exit("Download complete!")
+		print("Complete!")
+		sys.exit(0)
 		
 	if args.configfile is None:
-		assert args.directory is not None, "Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!)"
+		if args.directory is None, 
+			print("Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!")
+			sys.exit(1)
 		run_name = args.directory.name
 		generate_sample_table(args.directory, run_name)
 		config_file = run_name + "_config.yaml"
@@ -291,12 +298,14 @@ if __name__ == '__main__':
 			neg = [args.neg_prefix]
 		write_config_file(run_name, config_file, args.data, [args.add_breseq, args.remove_freebayes, neg])
 		if args.config_only:
-			exit("Configuration file and sample table generated!")
+			print("Configuration file and sample table generated!")
+			sys.exit(0)
 	else:
 		config_file = args.configfile
 	
 	if not any([allowed[x] for x in allowed]):
-		exit("No task specified! Please provide at least one of 'all', 'postprocess', or 'ncov_tools'! See 'signalexe.py -h' for details!")
+		print("No task specified! Please provide at least one of 'all', 'postprocess', or 'ncov_tools'! See 'signalexe.py -h' for details!")
+		sys.exit(1)
 	else:
 		if args.verbose: alt_options.append('--verbose')
 		if args.quiet: alt_options.append('--quiet')
@@ -331,4 +340,5 @@ if __name__ == '__main__':
 					else:
 						print(f"Some jobs failed while running SIGNAL {task}! Check SIGNAL inputs, logs, and results and try again!")
 	
-	exit("SIGNAL run complete! Check corresponding snakemake logs for any details!")
+	print("SIGNAL run complete! Check corresponding snakemake logs for any details!")
+	sys.exit(0)

--- a/signalexe.py
+++ b/signalexe.py
@@ -133,7 +133,7 @@ def write_sample_table(sample_data, output_table):
 		for sample in sample_data:
 			out_fh.write(",".join(sample) + '\n')
 
-def download_dependences(dir_name):
+def download_dependencies(dir_name):
 	script = os.path.join(script_path, 'scripts', 'get_data_dependencies.sh')
 	subprocess.run(['bash', script, '-d', dir_name, '-a', 'MN908947.3'])
 
@@ -281,10 +281,10 @@ if __name__ == '__main__':
 	
 	if args.dependencies:
 		print("Downloading necessary reference and dependency files!")
-		download_dependences(args.data)
+		download_dependencies(args.data)
 		print("Complete!")
 		
-	if (args.configfile is None) and (not allowed['install']):
+	if args.configfile is None:
 		assert args.directory is not None, "Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!)"
 		run_name = args.directory.name
 		generate_sample_table(args.directory, run_name)

--- a/signalexe.py
+++ b/signalexe.py
@@ -251,7 +251,7 @@ def install_signal(frontend, data='data'):
 	dep_snakefile = os.path.join(script_path, 'resources', 'dependencies')
 	assert os.path.exists(dep_snakefile)
 	try:
-		subprocess.run(f"snakemake -s {dep_snakefile} --conda-frontend {frontend} --cores 1 --use-conda --conda-prefix=$PWD/.snakemake/conda --quiet", shell=True, check=True)
+		subprocess.run(f"snakemake -s {dep_snakefile} --conda-frontend {frontend} --cores 1 --use-conda --conda-prefix=$PWD/.snakemake/conda", shell=True, check=True)
 	except subprocess.CalledProcessError: 
 		print("Installation of environments failed!")
 		sys.exit(1)

--- a/signalexe.py
+++ b/signalexe.py
@@ -286,7 +286,6 @@ if __name__ == '__main__':
 		
 	if (args.configfile is None) and (not allowed['install']):
 		assert args.directory is not None, "Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!)"
-			sys.exit(1)
 		run_name = args.directory.name
 		generate_sample_table(args.directory, run_name)
 		config_file = run_name + "_config.yaml"

--- a/signalexe.py
+++ b/signalexe.py
@@ -283,6 +283,7 @@ if __name__ == '__main__':
 		print("Downloading necessary reference and dependency files!")
 		download_dependencies(args.data)
 		print("Complete!")
+		sys.exit(0)
 		
 	if args.configfile is None:
 		assert args.directory is not None, "Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!)"

--- a/signalexe.py
+++ b/signalexe.py
@@ -283,11 +283,9 @@ if __name__ == '__main__':
 		print("Downloading necessary reference and dependency files!")
 		download_dependences(args.data)
 		print("Complete!")
-		sys.exit(0)
 		
-	if args.configfile is None:
-		if args.directory is None: 
-			print("Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!")
+	if (args.configfile is None) and (not allowed['install']):
+		assert args.directory is not None, "Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!)"
 			sys.exit(1)
 		run_name = args.directory.name
 		generate_sample_table(args.directory, run_name)

--- a/signalexe.py
+++ b/signalexe.py
@@ -286,7 +286,7 @@ if __name__ == '__main__':
 		sys.exit(0)
 		
 	if args.configfile is None:
-		if args.directory is None, 
+		if args.directory is None: 
 			print("Please provide '--directory' to proceed! ('--configfile' if a configuration file already exists!")
 			sys.exit(1)
 		run_name = args.directory.name


### PR DESCRIPTION
- Renaming of SIGNAL executable to avoid Python package naming conflicts signalexe.py and tweaked execution of snakemake to prevent inconvenient re-runs
- Option to install all the per-rule environments (signalexe.py install)
- Improved handling of failed samples including an added log listing those that fail assembly for quicker troubleshooting
- Improving file linking for ncov-tools to properly exclude failing samples before running
- Updates to per-rule conda environments to remove stale packages
- Nextclade dataset download now skippable if tag requested in configuration file matches already existing dataset, similarly to Pangolin and Nextclade software