### PR TITLE
Patch 1.6.4

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -647,9 +647,9 @@ rule run_freebayes:
         done
         
         # apply ambiguous variants first using IUPAC codes. this variant set cannot contain indels or the subsequent step will break
-        bcftools consensus -f {input.reference} -I {params.out}.ambiguous.norm.vcf.gz > {params.out}.ambiguous.fasta 
+        bcftools consensus -s '-' -f {input.reference} -I {params.out}.ambiguous.norm.vcf.gz > {params.out}.ambiguous.fasta 
         # apply remaninng variants, including indels
-        bcftools consensus -f {params.out}.ambiguous.fasta -m {params.out}.mask.txt {params.out}.fixed.norm.vcf.gz | sed s/MN908947\\.3.*/{wildcards.sn}/ > {output.consensus}
+        bcftools consensus -s '-' -f {params.out}.ambiguous.fasta -m {params.out}.mask.txt {params.out}.fixed.norm.vcf.gz | sed s/MN908947\\.3.*/{wildcards.sn}/ > {output.consensus}
         """
 
 rule consensus_compare:

--- a/Snakefile
+++ b/Snakefile
@@ -647,9 +647,9 @@ rule run_freebayes:
         done
         
         # apply ambiguous variants first using IUPAC codes. this variant set cannot contain indels or the subsequent step will break
-        bcftools consensus -s '-' -f {input.reference} -I {params.out}.ambiguous.norm.vcf.gz > {params.out}.ambiguous.fasta 
+        bcftools consensus -f {input.reference} -I {params.out}.ambiguous.norm.vcf.gz > {params.out}.ambiguous.fasta 
         # apply remaninng variants, including indels
-        bcftools consensus -s '-' -f {params.out}.ambiguous.fasta -m {params.out}.mask.txt {params.out}.fixed.norm.vcf.gz | sed s/MN908947\\.3.*/{wildcards.sn}/ > {output.consensus}
+        bcftools consensus -f {params.out}.ambiguous.fasta -m {params.out}.mask.txt {params.out}.fixed.norm.vcf.gz | sed s/MN908947\\.3.*/{wildcards.sn}/ > {output.consensus}
         """
 
 rule consensus_compare:

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -1343,18 +1343,41 @@ class Sample:
 
 
         if ivarlin['lineage'] != fblin['lineage'] and fblin['lineage'] is not None:
-            assert ivarlin['pangolin_ver'] == fblin['pangolin_ver']
-            assert ivarlin['pangodata_ver'] == fblin['pangodata_ver']
+           # pangolin version check (should match, but will report discrepency
+            try:
+                assert ivarlin['pangolin_ver'] == fblin['pangolin_ver']
+                pangolin_version = f"{ivarlin['pangolin_ver']}"
+            except AssertionError:
+                pangolin_version = f"{ivarlin['pangolin_ver']} (FB: {fblin['pangolin_ver']})"
+            
+            # pangodata version (should match, but will report discrepency)
+            try:
+                assert ivarlin['pangodata_ver'] == fblin['pangodata_ver']
+                pangodata_version = f"{ivarlin['pangodata_ver']}"
+            except AssertionError:
+                pangodata_version = f"{ivarlin['pangodata_ver']} (FB: {fblin['pangodata_ver']})"
+            
+            # report assigned clades between iVar and FreeBayes
             if ivarlin['clade'] == fblin['clade']:
-                 self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
-                                 'pangolin_ver': ivarlin['pangolin_ver'],
-                                 'pangodata_ver': ivarlin['pangodata_ver'],
-                                 'clade': ivarlin['clade'] }
+                assigned_clade = f"{ivarlin['clade']}"
             else:
-                 self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
-                                 'pangolin_ver': ivarlin['pangolin_ver'],
-                                 'pangodata_ver': ivarlin['pangodata_ver'],
-                                 'clade': str(ivarlin['clade'] + " (FB: %s)" %(fblin['clade'])) }
+                assigned_clade = f"{ivarlin['clade']} (FB: {fblin['clade']})"
+
+            self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
+                            'pangolin_ver': pangolin_version,
+                            'pangodata_ver': pangodata_version,
+                             'clade': assigned_clade }
+            
+            # if ivarlin['clade'] == fblin['clade']:
+                 # self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
+                                 # 'pangolin_ver': ivarlin['pangolin_ver'],
+                                 # 'pangodata_ver': ivarlin['pangodata_ver'],
+                                 # 'clade': ivarlin['clade'] }
+            # else:
+                 # self.lineage = { 'lineage': str(ivarlin['lineage'] + " (FB: %s)" %(fblin['lineage'])),
+                                 # 'pangolin_ver': ivarlin['pangolin_ver'],
+                                 # 'pangodata_ver': ivarlin['pangodata_ver'],
+                                 # 'clade': str(ivarlin['clade'] + " (FB: %s)" %(fblin['clade'])) }
         else:
             self.lineage = ivarlin
 

--- a/scripts/signal_postprocess.py
+++ b/scripts/signal_postprocess.py
@@ -17,7 +17,7 @@ long_git_id = '$Id: b158164f87c79271ddc9d1083e64e4be1fc26d8e $'
 
 assert long_git_id.startswith('$Id: ')
 #short_git_id = long_git_id[5:12]
-short_git_id = "v1.6.3"
+short_git_id = "v1.6.4"
 
 # Suppresses matplotlib warning (https://github.com/jaleezyy/covid-19-signal/issues/59)
 # Creates a small memory leak, but it's nontrivial to fix, and won't be a practical concern!

--- a/signalexe.py
+++ b/signalexe.py
@@ -184,6 +184,10 @@ viral_reference_feature_coords: "{data_directory}/MN908947.3.gff3"
 run_breseq: {opt_tasks[0]}
 # Used as --reference argument to 'breseq'
 breseq_reference: "{data_directory}/MN908947.3.gbk"
+# Used as --polymorphism-minimum-variant-coverage-each-strand, --polymorphism-frequency-cutoff arguments
+# Parameters needed to determine thresholds for minor variant detection
+polymorphism_variant_coverage: 2
+polymorphism_frequency: 0.05
 
 # run freebayes for variant and consensus calling (as well as ivar)
 run_freebayes: {opt_tasks[1]}

--- a/signalexe.py
+++ b/signalexe.py
@@ -274,7 +274,7 @@ if __name__ == '__main__':
 	# note: add root_dir to determine the root directory of SIGNAL
 	script_path = os.path.join(os.path.abspath(sys.argv[0]).rsplit("/",1)[0])
 	args, allowed = create_parser()
-	version = 'v1.6.3'
+	version = 'v1.6.4'
 	alt_options = []
 	
 	if args.version:


### PR DESCRIPTION
- added Breseq parameters for minor variant thresholds to be defined by the user
- modified output when software versions do not match when assessing lineage output as opposed to exiting the program with an error outright